### PR TITLE
feat: Add cursor-based pagination to fetchMarkets

### DIFF
--- a/core/src/BaseExchange.ts
+++ b/core/src/BaseExchange.ts
@@ -1,4 +1,4 @@
-import { UnifiedMarket, UnifiedEvent, PriceCandle, CandleInterval, OrderBook, Trade, Order, Position, Balance, CreateOrderParams } from './types';
+import { UnifiedMarket, UnifiedEvent, PriceCandle, CandleInterval, OrderBook, Trade, Order, Position, Balance, CreateOrderParams, PaginatedResult } from './types';
 import { getExecutionPrice, getExecutionPriceDetailed, ExecutionPriceResult } from './utils/math';
 import { MarketNotFound, EventNotFound } from './errors';
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
@@ -29,6 +29,7 @@ export interface ImplicitApiMethodInfo {
 export interface MarketFilterParams {
     limit?: number;
     offset?: number;
+    cursor?: string;
     sort?: 'volume' | 'liquidity' | 'newest';
     status?: 'active' | 'inactive' | 'closed' | 'all'; // Filter by market status (default: 'active', 'inactive' and 'closed' are interchangeable)
     searchIn?: 'title' | 'description' | 'both'; // Where to search (default: 'title')
@@ -168,6 +169,11 @@ export interface ExchangeCredentials {
     funderAddress?: string;  // The address funding the trades (defaults to signer address)
 }
 
+export interface PredictionMarketExchangeOptions {
+    credentials?: ExchangeCredentials;
+    snapshotTTL?: number;
+}
+
 // ----------------------------------------------------------------------------
 // Base Exchange Class
 // ----------------------------------------------------------------------------
@@ -183,6 +189,8 @@ export abstract class PredictionMarketExchange {
     public markets: Record<string, UnifiedMarket> = {};
     public marketsBySlug: Record<string, UnifiedMarket> = {};
     public loadedMarkets: boolean = false;
+    private snapshots: Map<string, { markets: UnifiedMarket[]; createdAt: number }> = new Map();
+    private snapshotTTL: number;
 
     // Implicit API (merged across multiple defineImplicitApi calls)
     protected apiDescriptor?: ApiDescriptor;
@@ -204,8 +212,29 @@ export abstract class PredictionMarketExchange {
         watchTrades: false,
     };
 
-    constructor(credentials?: ExchangeCredentials) {
-        this.credentials = credentials;
+    constructor(
+        optionsOrCredentials?: ExchangeCredentials | PredictionMarketExchangeOptions,
+        legacyOptions?: PredictionMarketExchangeOptions
+    ) {
+        // Backward compatibility:
+        // - Legacy: new Exchange(credentials)
+        // - Legacy: super(credentials, { snapshotTTL })
+        // - New:    super({ credentials, snapshotTTL })
+        if (legacyOptions) {
+            this.credentials = optionsOrCredentials as ExchangeCredentials | undefined;
+            this.snapshotTTL = legacyOptions.snapshotTTL ?? 5 * 60 * 1000;
+        } else if (
+            optionsOrCredentials &&
+            typeof optionsOrCredentials === 'object' &&
+            ('credentials' in optionsOrCredentials || 'snapshotTTL' in optionsOrCredentials)
+        ) {
+            const options = optionsOrCredentials as PredictionMarketExchangeOptions;
+            this.credentials = options.credentials;
+            this.snapshotTTL = options.snapshotTTL ?? 5 * 60 * 1000;
+        } else {
+            this.credentials = optionsOrCredentials as ExchangeCredentials | undefined;
+            this.snapshotTTL = 5 * 60 * 1000;
+        }
         this.http = axios.create();
 
         // Request Interceptor
@@ -327,7 +356,50 @@ export abstract class PredictionMarketExchange {
      * markets = exchange.fetch_markets(slug='will-trump-win')
      */
     async fetchMarkets(params?: MarketFetchParams): Promise<UnifiedMarket[]> {
+        if (params?.cursor) {
+            const paginated = await this.fetchMarketsPaginated(params);
+            return paginated.data;
+        }
         return this.fetchMarketsImpl(params);
+    }
+
+    /**
+     * Fetch markets with stable cursor-based pagination.
+     * Use this when you need consistency across pages even if market ordering drifts.
+     */
+    async fetchMarketsPaginated(params?: MarketFetchParams): Promise<PaginatedResult<UnifiedMarket>> {
+        this.cleanExpiredSnapshots();
+
+        if (params?.cursor) {
+            return this.fetchMarketsByCursor(params);
+        }
+
+        // Preserve old "get everything" behavior when no pagination inputs are provided.
+        if (params?.limit === undefined && params?.offset === undefined) {
+            const markets = await this.fetchMarketsImpl(params);
+            return {
+                data: markets,
+                total: markets.length,
+            };
+        }
+
+        const { limit, offset, cursor, ...baseParams } = params || {};
+        const pageSize = limit ?? 10000;
+        const startOffset = offset ?? 0;
+
+        // Fetch a stable snapshot with pagination params removed.
+        const markets = await this.fetchMarketsImpl(baseParams);
+        const snapshotId = this.createSnapshot(markets);
+        const nextOffset = startOffset + pageSize;
+        const nextCursor = nextOffset < markets.length
+            ? this.encodeCursor(snapshotId, nextOffset)
+            : undefined;
+
+        return {
+            data: markets.slice(startOffset, startOffset + pageSize),
+            nextCursor,
+            total: markets.length,
+        };
     }
 
     /**
@@ -1213,6 +1285,59 @@ export abstract class PredictionMarketExchange {
      */
     protected mapImplicitApiError(error: any): any {
         throw error;
+    }
+
+    private createSnapshot(markets: UnifiedMarket[]): string {
+        const snapshotId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        this.snapshots.set(snapshotId, { markets, createdAt: Date.now() });
+        return snapshotId;
+    }
+
+    private encodeCursor(snapshotId: string, offset: number): string {
+        const payload = JSON.stringify({ s: snapshotId, o: offset });
+        return Buffer.from(payload, 'utf8').toString('base64');
+    }
+
+    private decodeCursor(cursor: string): { snapshotId: string; offset: number } {
+        try {
+            const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+            const parsed = JSON.parse(decoded);
+            if (!parsed?.s || typeof parsed?.o !== 'number') {
+                throw new Error('Invalid cursor payload');
+            }
+            return { snapshotId: parsed.s, offset: parsed.o };
+        } catch {
+            throw new Error('Invalid cursor format');
+        }
+    }
+
+    private cleanExpiredSnapshots(): void {
+        const now = Date.now();
+        for (const [snapshotId, snapshot] of this.snapshots.entries()) {
+            if (now - snapshot.createdAt > this.snapshotTTL) {
+                this.snapshots.delete(snapshotId);
+            }
+        }
+    }
+
+    private async fetchMarketsByCursor(params: MarketFetchParams): Promise<PaginatedResult<UnifiedMarket>> {
+        const { snapshotId, offset } = this.decodeCursor(params.cursor!);
+        const snapshot = this.snapshots.get(snapshotId);
+        if (!snapshot) {
+            throw new Error('Cursor has expired. Please restart pagination from the first page.');
+        }
+
+        const pageSize = params.limit ?? 10000;
+        const nextOffset = offset + pageSize;
+        const nextCursor = nextOffset < snapshot.markets.length
+            ? this.encodeCursor(snapshotId, nextOffset)
+            : undefined;
+
+        return {
+            data: snapshot.markets.slice(offset, offset + pageSize),
+            nextCursor,
+            total: snapshot.markets.length,
+        };
     }
 
     /**

--- a/core/src/exchanges/baozi/index.ts
+++ b/core/src/exchanges/baozi/index.ts
@@ -57,6 +57,7 @@ import {
 export interface BaoziExchangeOptions {
     credentials?: ExchangeCredentials;
     rpcUrl?: string;
+    snapshotTTL?: number;
 }
 
 export class BaoziExchange extends PredictionMarketExchange {
@@ -83,15 +84,17 @@ export class BaoziExchange extends PredictionMarketExchange {
     constructor(options?: ExchangeCredentials | BaoziExchangeOptions) {
         let credentials: ExchangeCredentials | undefined;
         let rpcUrl: string | undefined;
+        let snapshotTTL: number | undefined;
 
         if (options && 'credentials' in options) {
             credentials = options.credentials;
             rpcUrl = (options as BaoziExchangeOptions).rpcUrl;
+            snapshotTTL = (options as BaoziExchangeOptions).snapshotTTL;
         } else {
             credentials = options as ExchangeCredentials | undefined;
         }
 
-        super(credentials);
+        super({ credentials, snapshotTTL });
 
         rpcUrl = rpcUrl
             || process.env.BAOZI_RPC_URL

--- a/core/src/exchanges/kalshi/index.ts
+++ b/core/src/exchanges/kalshi/index.ts
@@ -17,6 +17,7 @@ export type { KalshiWebSocketConfig };
 export interface KalshiExchangeOptions {
     credentials?: ExchangeCredentials;
     websocket?: KalshiWebSocketConfig;
+    snapshotTTL?: number;
 }
 
 export class KalshiExchange extends PredictionMarketExchange {
@@ -43,17 +44,19 @@ export class KalshiExchange extends PredictionMarketExchange {
         // Support both old signature (credentials only) and new signature (options object)
         let credentials: ExchangeCredentials | undefined;
         let wsConfig: KalshiWebSocketConfig | undefined;
+        let snapshotTTL: number | undefined;
 
         if (options && 'credentials' in options) {
             // New signature: KalshiExchangeOptions
             credentials = options.credentials;
             wsConfig = options.websocket;
+            snapshotTTL = options.snapshotTTL;
         } else {
             // Old signature: ExchangeCredentials directly
             credentials = options as ExchangeCredentials | undefined;
         }
 
-        super(credentials);
+        super({ credentials, snapshotTTL });
         this.wsConfig = wsConfig;
 
         if (credentials?.apiKey && credentials?.privateKey) {

--- a/core/src/exchanges/limitless/index.ts
+++ b/core/src/exchanges/limitless/index.ts
@@ -40,6 +40,7 @@ export type { LimitlessWebSocketConfig };
 export interface LimitlessExchangeOptions {
     credentials?: ExchangeCredentials;
     websocket?: LimitlessWebSocketConfig;
+    snapshotTTL?: number;
 }
 
 export class LimitlessExchange extends PredictionMarketExchange {
@@ -67,11 +68,13 @@ export class LimitlessExchange extends PredictionMarketExchange {
         // Support both old signature (credentials only) and new signature (options object)
         let credentials: ExchangeCredentials | undefined;
         let wsConfig: LimitlessWebSocketConfig | undefined;
+        let snapshotTTL: number | undefined;
 
         if (options && 'credentials' in options) {
             // New signature: LimitlessExchangeOptions
             credentials = options.credentials;
             wsConfig = options.websocket;
+            snapshotTTL = options.snapshotTTL;
         } else if (options && 'privateKey' in options) {
             // Support direct privateKey for easier initialization
             credentials = options as ExchangeCredentials;
@@ -80,7 +83,7 @@ export class LimitlessExchange extends PredictionMarketExchange {
             credentials = options as ExchangeCredentials | undefined;
         }
 
-        super(credentials);
+        super({ credentials, snapshotTTL });
         this.wsConfig = wsConfig;
 
         // Initialize auth if API key or private key are provided

--- a/core/src/exchanges/polymarket/index.ts
+++ b/core/src/exchanges/polymarket/index.ts
@@ -23,6 +23,7 @@ export type { PolymarketWebSocketConfig };
 export interface PolymarketExchangeOptions {
     credentials?: ExchangeCredentials;
     websocket?: PolymarketWebSocketConfig;
+    snapshotTTL?: number;
 }
 
 export class PolymarketExchange extends PredictionMarketExchange {
@@ -51,17 +52,19 @@ export class PolymarketExchange extends PredictionMarketExchange {
         // Support both old signature (credentials only) and new signature (options object)
         let credentials: ExchangeCredentials | undefined;
         let wsConfig: PolymarketWebSocketConfig | undefined;
+        let snapshotTTL: number | undefined;
 
         if (options && 'credentials' in options) {
             // New signature: PolymarketExchangeOptions
             credentials = options.credentials;
             wsConfig = options.websocket;
+            snapshotTTL = options.snapshotTTL;
         } else {
             // Old signature: ExchangeCredentials directly
             credentials = options as ExchangeCredentials | undefined;
         }
 
-        super(credentials);
+        super({ credentials, snapshotTTL });
         this.wsConfig = wsConfig;
 
         // Initialize auth if credentials are provided

--- a/core/src/server/openapi.yaml
+++ b/core/src/server/openapi.yaml
@@ -72,6 +72,41 @@ paths:
                         items:
                           $ref: '#/components/schemas/UnifiedMarket'
 
+  /api/{exchange}/fetchMarketsPaginated:
+    post:
+      summary: Fetch Markets (Paginated)
+      operationId: fetchMarketsPaginated
+      parameters:
+        - $ref: '#/components/parameters/ExchangeParam'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                args:
+                  type: array
+                  maxItems: 1
+                  items:
+                    $ref: '#/components/schemas/MarketFilterParams'
+                credentials:
+                  $ref: '#/components/schemas/ExchangeCredentials'
+                verbose:
+                  type: boolean
+                  description: Enable verbose logging for this request
+      responses:
+        '200':
+          description: Cursor-paginated list of unified markets
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/PaginatedMarketResult'
+
   /api/{exchange}/fetchMarket:
     post:
       summary: Fetch Single Market
@@ -975,6 +1010,20 @@ components:
         down:
           $ref: '#/components/schemas/MarketOutcome'
 
+    PaginatedMarketResult:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UnifiedMarket'
+        nextCursor:
+          type: string
+          description: Opaque cursor for fetching the next page
+        total:
+          type: integer
+          description: Total number of markets in this snapshot
+
     MarketOutcome:
       type: object
       properties:
@@ -1164,6 +1213,9 @@ components:
           default: 10000
         offset:
           type: integer
+        cursor:
+          type: string
+          description: Opaque cursor returned by a previous fetchMarkets call
         sort:
           type: string
           enum: [volume, liquidity, newest]

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -56,6 +56,12 @@ export interface UnifiedMarket {
     down?: MarketOutcome;
 }
 
+export interface PaginatedResult<T> {
+    data: T[];
+    nextCursor?: string;
+    total: number;
+}
+
 export type CandleInterval = '1m' | '5m' | '15m' | '1h' | '6h' | '1d';
 
 export interface PriceCandle {

--- a/core/test/unit/fetchMarketsCursor.test.ts
+++ b/core/test/unit/fetchMarketsCursor.test.ts
@@ -1,0 +1,93 @@
+import { MarketFetchParams, PredictionMarketExchange, EventFetchParams } from '../../src/BaseExchange';
+import { UnifiedEvent, UnifiedMarket } from '../../src/types';
+
+class CursorTestExchange extends PredictionMarketExchange {
+    get name() { return 'CursorTestExchange'; }
+    public fetchMarketsImplCalls = 0;
+    private readonly mockMarkets: UnifiedMarket[];
+
+    constructor(markets: UnifiedMarket[], snapshotTTL?: number) {
+        super(undefined, { snapshotTTL });
+        this.mockMarkets = markets;
+    }
+
+    protected async fetchMarketsImpl(_params?: MarketFetchParams): Promise<UnifiedMarket[]> {
+        this.fetchMarketsImplCalls++;
+        return this.mockMarkets;
+    }
+
+    protected async fetchEventsImpl(_params: EventFetchParams): Promise<UnifiedEvent[]> {
+        return [];
+    }
+}
+
+function makeMarkets(count: number): UnifiedMarket[] {
+    const markets: UnifiedMarket[] = [];
+    for (let i = 0; i < count; i++) {
+        markets.push({
+            marketId: `m-${i}`,
+            title: `Market ${i}`,
+            description: '',
+            outcomes: [],
+            resolutionDate: new Date('2030-01-01T00:00:00.000Z'),
+            volume24h: i,
+            liquidity: i,
+            url: `https://example.com/m-${i}`,
+        });
+    }
+    return markets;
+}
+
+describe('fetchMarketsPaginated cursor pagination', () => {
+    it('should return consistent pages from a snapshot', async () => {
+        const exchange = new CursorTestExchange(makeMarkets(6), 60_000);
+
+        const page1 = await exchange.fetchMarketsPaginated({ limit: 2 });
+        expect(page1.data.map(m => m.marketId)).toEqual(['m-0', 'm-1']);
+        expect(page1.total).toBe(6);
+        expect(page1.nextCursor).toBeDefined();
+        expect(exchange.fetchMarketsImplCalls).toBe(1);
+
+        const page2 = await exchange.fetchMarketsPaginated({ limit: 2, cursor: page1.nextCursor! });
+        expect(page2.data.map(m => m.marketId)).toEqual(['m-2', 'm-3']);
+        expect(page2.total).toBe(6);
+        expect(page2.nextCursor).toBeDefined();
+        // Should not refetch from implementation when cursor is used
+        expect(exchange.fetchMarketsImplCalls).toBe(1);
+
+        const page3 = await exchange.fetchMarketsPaginated({ limit: 2, cursor: page2.nextCursor! });
+        expect(page3.data.map(m => m.marketId)).toEqual(['m-4', 'm-5']);
+        expect(page3.nextCursor).toBeUndefined();
+        expect(exchange.fetchMarketsImplCalls).toBe(1);
+    });
+
+    it('should return full data with no cursor/limit and no nextCursor', async () => {
+        const exchange = new CursorTestExchange(makeMarkets(3), 60_000);
+        const result = await exchange.fetchMarketsPaginated();
+
+        expect(result.data).toHaveLength(3);
+        expect(result.total).toBe(3);
+        expect(result.nextCursor).toBeUndefined();
+        expect(exchange.fetchMarketsImplCalls).toBe(1);
+    });
+
+    it('should reject expired cursor after TTL', async () => {
+        const exchange = new CursorTestExchange(makeMarkets(4), 1);
+        const page1 = await exchange.fetchMarketsPaginated({ limit: 2 });
+        expect(page1.nextCursor).toBeDefined();
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        await expect(
+            exchange.fetchMarketsPaginated({ limit: 2, cursor: page1.nextCursor! })
+        ).rejects.toThrow('Cursor has expired');
+    });
+
+    it('should keep fetchMarkets non-breaking and return plain arrays', async () => {
+        const exchange = new CursorTestExchange(makeMarkets(3), 60_000);
+        const markets = await exchange.fetchMarkets({ limit: 2 });
+
+        expect(Array.isArray(markets)).toBe(true);
+        expect(markets).toHaveLength(3); // fetchMarketsImpl in mock ignores limit
+    });
+});


### PR DESCRIPTION
addresses #41

- Added cursor-based pagination support in BaseExchange via a new fetchMarketsPaginated method, using snapshot-backed cursors for stable pagination across calls.
- Introduced a reusable PaginatedResult<T> type to standardize paginated responses (data, nextCursor, total).
Kept fetchMarkets backward-compatible (still returns UnifiedMarket[]) while enabling cursor-based pagination through the new paginated method.
- Updated exchange integrations and constructor wiring (Baozi, Kalshi, Limitless, Polymarket, plus shared base behavior) to support configurable pagination snapshot TTL and unified options handling with legacy constructor compatibility.
- Updated OpenAPI documentation to preserve the existing fetchMarkets response shape and add the new fetchMarketsPaginated endpoint.
- Added/updated unit and compliance tests to validate cursor pagination behavior (consistency, cursor expiry, fallback behavior) and confirm backward compatibility.

### Notes

- This would change the api surface a bit for fetchMarkets since the paginated version returns the new paginated object, using a separate fetchMarketsPaginated for now as to not be a breaking change. Maybe in v3.0.0 can be replaced
- I don't know whats better ergonomically wrt the PredictionMarketExchange constructor, whether it should have 2 params for the creds + config options or if it should just be 1 object where things could be added in the future? 
- There is a tradeoff in data freshness + the stability of being able to navigate the list, maybe can add some way to force refresh every time or a separate method to always get fresh data for people that want new markets immediately?