### PR TITLE
fix: keep Polymarket per-market image in UnifiedMarket mapping

### DIFF
--- a/core/src/exchanges/polymarket/utils.ts
+++ b/core/src/exchanges/polymarket/utils.ts
@@ -87,7 +87,7 @@ export function mapMarketToUnified(event: any, market: any, options: { useQuesti
         liquidity: Number(market.liquidity || market.rewards?.liquidity || 0),
         openInterest: Number(market.openInterest || market.open_interest || 0),
         url: `https://polymarket.com/event/${event.slug}`,
-        image: event.image || market.image || `https://polymarket.com/api/og?slug=${event.slug}`,
+        image: market.image || event.image || `https://polymarket.com/api/og?slug=${event.slug}`,
         category: event.category || event.tags?.[0]?.label,
         tags: event.tags?.map((t: any) => t.label) || []
     } as UnifiedMarket;

--- a/core/test/unit/normalizers/polymarket.test.ts
+++ b/core/test/unit/normalizers/polymarket.test.ts
@@ -113,6 +113,22 @@ describe('PolymarketNormalizer.normalizeMarket', () => {
         expect(market!.volume24h).toBe(77000);
     });
 
+    test('should prefer market image over event image when both are present', () => {
+        const altMarket: PolymarketRawMarket = {
+            ...RAW_MARKET,
+            image: 'https://example.com/market-image.png',
+        };
+        const event: PolymarketRawEvent = {
+            ...RAW_EVENT,
+            image: 'https://example.com/event-image.png',
+            markets: [altMarket],
+        };
+
+        const market = normalizer.normalizeMarket(event);
+
+        expect(market!.image).toBe('https://example.com/market-image.png');
+    });
+
     test('should handle end_date_iso fallback', () => {
         const altMarket: PolymarketRawMarket = {
             ...RAW_MARKET,


### PR DESCRIPTION
## Bug
Fixes https://github.com/pmxt-dev/pmxt/issues/62 — multi-market Polymarket events were assigning the same event-level image to every UnifiedMarket, even when the underlying market had its own image.

## Fix
- Updated Polymarket market normalization image precedence to prefer market-level image first.
- New precedence order:
  1) `market.image`
  2) `event.image`
  3) fallback OG image URL
- Added a focused unit test that verifies market image wins when both event and market images are present.

## Files changed
- `core/src/exchanges/polymarket/utils.ts`
- `core/test/unit/normalizers/polymarket.test.ts`

## Testing
- Added unit test coverage for the image precedence behavior in the Polymarket normalizer test suite.

Happy to adjust if you want stricter fallback behavior for empty-string image values as well.

Greetings, saschabuehrle
