### PR TITLE
fix spurious nonetwork on watch_address balance rpc

### DIFF
--- a/core/src/exchanges/limitless/client.ts
+++ b/core/src/exchanges/limitless/client.ts
@@ -176,7 +176,10 @@ export class LimitlessClient {
         const ABI = ["function balanceOf(address) view returns (uint256)", "function decimals() view returns (uint8)"];
         
         // Use a public RPC for Base
-        const provider = new providers.JsonRpcProvider('https://mainnet.base.org');
+        const provider = new providers.JsonRpcProvider('https://mainnet.base.org', {
+            chainId: 8453,
+            name: 'base',
+        });
         const contract = new Contract(USDC_ADDRESS, ABI, provider);
 
         const balance = await contract.balanceOf(this.signer.address);

--- a/core/src/exchanges/limitless/index.ts
+++ b/core/src/exchanges/limitless/index.ts
@@ -463,7 +463,12 @@ export class LimitlessExchange extends PredictionMarketExchange {
 
     private async getAddressOnChainBalance(targetAddress: string): Promise<Balance[]> {
         // Query USDC balance directly from Base chain
-        const provider = new providers.JsonRpcProvider('https://mainnet.base.org');
+        // Static network avoids ethers v5 auto-detect (eth_chainId) which can throw
+        // noNetwork / NETWORK_ERROR on flaky public RPCs (#92).
+        const provider = new providers.JsonRpcProvider('https://mainnet.base.org', {
+            chainId: 8453,
+            name: 'base',
+        });
 
         // Get USDC contract address for Base
         const usdcAddress = getContractAddress('USDC');

--- a/core/src/exchanges/polymarket/index.ts
+++ b/core/src/exchanges/polymarket/index.ts
@@ -636,7 +636,12 @@ export class PolymarketExchange extends PredictionMarketExchange {
         if (!ethers.utils.isAddress(address)) {
             throw new Error(`Invalid address: ${address}`);
         }
-        const provider = new ethers.providers.JsonRpcProvider('https://polygon-rpc.com');
+        // Static network avoids ethers v5 auto-detect (eth_chainId) which can throw
+        // noNetwork / NETWORK_ERROR on flaky public RPCs (#92).
+        const provider = new ethers.providers.JsonRpcProvider('https://polygon-rpc.com', {
+            chainId: 137,
+            name: 'matic',
+        });
         const usdcAddress = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'; // USDC.e (Bridged)
         const usdcAbi = [
             'function balanceOf(address) view returns (uint256)',


### PR DESCRIPTION
Here’s a cleaner, sharper version:

---

## What changed

In ethers v5, `JsonRpcProvider` performs automatic network detection (`eth_chainId`) on first use. Public RPC endpoints can fail or rate-limit this call, causing `noNetwork` / `NETWORK_ERROR` even when connectivity is fine.

After #90, these errors surfaced because they’re no longer swallowed in `fetchWatchedAddressActivity`.

To fix this, we now pass a static network (chainId + name) for Polygon and Base, bypassing auto-detection and using the RPC strictly for contract reads.

## Files

* `core/src/exchanges/polymarket/index.ts` — Polygon (137)
* `core/src/exchanges/limitless/index.ts` — Base (8453)
* `core/src/exchanges/limitless/client.ts` — apply same static network for `getBalance()`

Closes #92

---

**Summary:** Use static network config to avoid RPC `eth_chainId` failures and eliminate intermittent `NETWORK_ERROR`.
