### PR TITLE
Fix spurious balance fetch errors

### DIFF
--- a/core/src/exchanges/limitless/client.ts
+++ b/core/src/exchanges/limitless/client.ts
@@ -176,7 +176,10 @@ export class LimitlessClient {
         const ABI = ["function balanceOf(address) view returns (uint256)", "function decimals() view returns (uint8)"];
         
         // Use a public RPC for Base
-        const provider = new providers.JsonRpcProvider('https://mainnet.base.org');
+        const provider = new providers.StaticJsonRpcProvider('https://mainnet.base.org', {
+            chainId: 8453,
+            name: 'base',
+        });
         const contract = new Contract(USDC_ADDRESS, ABI, provider);
 
         const balance = await contract.balanceOf(this.signer.address);

--- a/core/src/exchanges/limitless/index.ts
+++ b/core/src/exchanges/limitless/index.ts
@@ -466,7 +466,7 @@ export class LimitlessExchange extends PredictionMarketExchange {
         //
         // Static network avoids ethers v5 auto-detect (eth_chainId), which can throw
         // noNetwork / NETWORK_ERROR on flaky public RPCs (#92).
-        const provider = new providers.JsonRpcProvider('https://mainnet.base.org', {
+        const provider = new providers.StaticJsonRpcProvider('https://mainnet.base.org', {
             chainId: 8453,
             name: 'base',
         });

--- a/core/src/exchanges/limitless/index.ts
+++ b/core/src/exchanges/limitless/index.ts
@@ -463,7 +463,13 @@ export class LimitlessExchange extends PredictionMarketExchange {
 
     private async getAddressOnChainBalance(targetAddress: string): Promise<Balance[]> {
         // Query USDC balance directly from Base chain
-        const provider = new providers.JsonRpcProvider('https://mainnet.base.org');
+        //
+        // Static network avoids ethers v5 auto-detect (eth_chainId), which can throw
+        // noNetwork / NETWORK_ERROR on flaky public RPCs (#92).
+        const provider = new providers.JsonRpcProvider('https://mainnet.base.org', {
+            chainId: 8453,
+            name: 'base',
+        });
 
         // Get USDC contract address for Base
         const usdcAddress = getContractAddress('USDC');

--- a/core/src/exchanges/polymarket/index.ts
+++ b/core/src/exchanges/polymarket/index.ts
@@ -636,7 +636,12 @@ export class PolymarketExchange extends PredictionMarketExchange {
         if (!ethers.utils.isAddress(address)) {
             throw new Error(`Invalid address: ${address}`);
         }
-        const provider = new ethers.providers.JsonRpcProvider('https://polygon-rpc.com');
+        // Static network avoids ethers v5 auto-detect (eth_chainId), which can throw
+        // noNetwork / NETWORK_ERROR on flaky public RPCs (#92).
+        const provider = new ethers.providers.JsonRpcProvider('https://polygon-rpc.com', {
+            chainId: 137,
+            name: 'matic',
+        });
         const usdcAddress = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'; // USDC.e (Bridged)
         const usdcAbi = [
             'function balanceOf(address) view returns (uint256)',

--- a/core/src/exchanges/polymarket/index.ts
+++ b/core/src/exchanges/polymarket/index.ts
@@ -638,7 +638,7 @@ export class PolymarketExchange extends PredictionMarketExchange {
         }
         // Static network avoids ethers v5 auto-detect (eth_chainId), which can throw
         // noNetwork / NETWORK_ERROR on flaky public RPCs (#92).
-        const provider = new ethers.providers.JsonRpcProvider('https://polygon-rpc.com', {
+        const provider = new ethers.providers.StaticJsonRpcProvider('https://polygon-rpc.com', {
             chainId: 137,
             name: 'matic',
         });


### PR DESCRIPTION
Updates relevant exchange adapters to use `StaticJsonRpcProvider`, which is the ethers v5 mechanism to skip automatic network detection.

Note that when PMXT eventually upgrades to ethers v6, we'll be able to migrate back to `JsonRpcProvider`. (See the [migration guide](https://github.com/ethers-io/ethers.js/blob/b746c3cf6cd191e2357fa55751696676ffda060e/docs.wrm/migrating.wrm#L231-L244) and https://github.com/ethers-io/ethers.js/discussions/3994#discussioncomment-5710699).

Adapted from @mooncitydev's #94.

Closes #92.