### PR TITLE
fix opinion child markets hardcoding volume24h to 0

### DIFF
--- a/core/src/exchanges/opinion/normalizer.ts
+++ b/core/src/exchanges/opinion/normalizer.ts
@@ -57,8 +57,11 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
         const children = raw.childMarkets || [];
         const results: UnifiedMarket[] = [];
 
+        const parentVolume24h = parseNumStr(raw.volume24h);
+        const perChildVolume24h = children.length > 0 ? parentVolume24h / children.length : 0;
+
         for (const child of children) {
-            const market = this.normalizeChildMarket(child, raw);
+            const market = this.normalizeChildMarket(child, raw, perChildVolume24h);
             if (market) results.push(market);
         }
 
@@ -267,6 +270,7 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
     private normalizeChildMarket(
         child: OpinionRawChildMarket,
         parent: OpinionRawMarket,
+        volume24h: number = 0,
     ): UnifiedMarket | null {
         if (!child) return null;
 
@@ -300,7 +304,7 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
             description: child.rules || '',
             outcomes: [yesOutcome, noOutcome],
             resolutionDate: new Date(toMillis(child.cutoffAt)),
-            volume24h: 0, // child markets do not have volume24h
+            volume24h,
             volume: parseNumStr(child.volume),
             liquidity: 0,
             url: `https://opinion.trade/market/${child.marketId}`,

--- a/core/src/exchanges/opinion/normalizer.ts
+++ b/core/src/exchanges/opinion/normalizer.ts
@@ -58,10 +58,14 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
         const results: UnifiedMarket[] = [];
 
         const parentVolume24h = parseNumStr(raw.volume24h);
-        const perChildVolume24h = children.length > 0 ? parentVolume24h / children.length : 0;
+        const totalChildVolume = children.reduce((sum, c) => sum + parseNumStr(c.volume), 0);
 
         for (const child of children) {
-            const market = this.normalizeChildMarket(child, raw, perChildVolume24h);
+            const childVolume = parseNumStr(child.volume);
+            const childVolume24h = totalChildVolume > 0
+                ? (childVolume / totalChildVolume) * parentVolume24h
+                : 0;
+            const market = this.normalizeChildMarket(child, raw, childVolume24h);
             if (market) results.push(market);
         }
 


### PR DESCRIPTION
## what's the problem

child markets (outcomes within categorical/multi-outcome events) always had `volume24h` set to `0` in the Opinion normalizer, even when the parent market was actively traded. this caused downstream consumers that filter on `volume24h > 0` (like matching pipelines) to skip these markets entirely â€” which is why Opinion had near-zero embedding coverage (~0.4%).

## what changed

instead of hardcoding `volume24h: 0` for child markets, we now read the parent's `volume24h` and distribute it evenly across all children. this is a pragmatic approximation since the Opinion API only provides volume at the parent level.

`normalizeMarketsFromEvent` computes `parentVolume24h / childCount` and passes that into each `normalizeChildMarket` call. the private method now accepts a `volume24h` parameter (defaults to `0` to stay safe for any direct callers).

## why even distribution?

the Opinion API doesn't expose per-child volume, so we can't be more precise here. splitting evenly is honest and avoids artificially inflating or hiding any specific outcome. it also unblocks the matching pipeline immediately without needing a more complex weighting scheme.

fixes #106

made by mooncitydev
