### PR TITLE
docs: include exchange in WebSocket examples

### DIFF
--- a/docs/api-reference/watch-order-book.mdx
+++ b/docs/api-reference/watch-order-book.mdx
@@ -65,7 +65,7 @@ while (true) {
 
 ```json WebSocket
 // → Subscribe
-{ "id": "req-1", "action": "subscribe", "method": "watchOrderBook", "args": ["OUTCOME_ID", 10] }
+{ "id": "req-1", "action": "subscribe", "exchange": "polymarket", "method": "watchOrderBook", "args": ["OUTCOME_ID", 10] }
 
 // ← Subscription confirmed
 { "event": "subscribed", "id": "req-1" }
@@ -85,7 +85,7 @@ while (true) {
 }
 
 // → Unsubscribe
-{ "id": "req-1", "action": "unsubscribe" }
+{ "id": "req-1", "action": "unsubscribe", "exchange": "polymarket", "method": "watchOrderBook", "args": ["OUTCOME_ID"] }
 ```
 
 </CodeGroup>

--- a/docs/api-reference/watch-order-books.mdx
+++ b/docs/api-reference/watch-order-books.mdx
@@ -64,6 +64,7 @@ while (true) {
 {
   "id": "req-1",
   "action": "subscribe",
+  "exchange": "polymarket",
   "method": "watchOrderBooks",
   "args": [["OUTCOME_ID_1", "OUTCOME_ID_2", "OUTCOME_ID_3"], 10]
 }

--- a/docs/api-reference/watch-trades.mdx
+++ b/docs/api-reference/watch-trades.mdx
@@ -57,7 +57,7 @@ while (true) {
 
 ```json WebSocket
 // → Subscribe
-{ "id": "req-1", "action": "subscribe", "method": "watchTrades", "args": ["OUTCOME_ID"] }
+{ "id": "req-1", "action": "subscribe", "exchange": "polymarket", "method": "watchTrades", "args": ["OUTCOME_ID"] }
 
 // ← Data event
 {

--- a/docs/api-reference/websocket.mdx
+++ b/docs/api-reference/websocket.mdx
@@ -19,7 +19,7 @@ All messages are JSON text frames. A single connection supports multiple concurr
 ### Subscribe
 
 ```json
-{ "id": "req-1", "action": "subscribe", "method": "watchOrderBook", "args": ["OUTCOME_ID", 50] }
+{ "id": "req-1", "action": "subscribe", "exchange": "polymarket", "method": "watchOrderBook", "args": ["OUTCOME_ID", 50] }
 ```
 
 ### Data event
@@ -42,7 +42,7 @@ All messages are JSON text frames. A single connection supports multiple concurr
 ### Unsubscribe
 
 ```json
-{ "id": "req-1", "action": "unsubscribe" }
+{ "id": "req-1", "action": "unsubscribe", "exchange": "polymarket", "method": "watchOrderBook", "args": ["OUTCOME_ID"] }
 ```
 
 ### Error


### PR DESCRIPTION
## Summary
- Add the required `exchange` field to WebSocket subscribe examples.
- Include the matching `method` and `args` fields in unsubscribe examples so they match server subscription lookup.
- Cover the overview, order book, batch order book, and trades WebSocket docs.

## Tests
- `git diff --check`
- `Select-String` verification for `"exchange": "polymarket"` in updated examples
- Checked `core/src/server/ws-handler.ts` requires `id`, `action`, and `exchange`

Prepared with local automation assistance and reviewed before submission.