### PR TITLE
docs: sync hosted-pmxt custom endpoints

### DIFF
--- a/docs/api-reference/openapi-hosted.json
+++ b/docs/api-reference/openapi-hosted.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PMXT Hosted Router API",
     "description": "Hosted-only endpoints for cross-venue search, matching, arbitrage, and SQL.",
-    "version": "81efb2b"
+    "version": "480d46a"
   },
   "servers": [
     {
@@ -756,6 +756,16 @@
           },
           {
             "in": "query",
+            "name": "maxDifference",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "description": "Maximum price difference to include (0.0-1.0). Defaults to 0.20 when scanning opportunities with sort=priceDifference or minDifference > 0; pass 1 to include raw giant spreads.\n"
+          },
+          {
+            "in": "query",
             "name": "category",
             "schema": {
               "type": "string"
@@ -906,6 +916,16 @@
               "default": 0
             },
             "description": "Minimum price difference to include (0.0-1.0)."
+          },
+          {
+            "in": "query",
+            "name": "maxDifference",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "description": "Maximum price difference to include (0.0-1.0). Defaults to 0.20; pass 1 to include raw giant spreads.\n"
           },
           {
             "in": "query",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5253,6 +5253,7 @@ Bulk cross-venue price comparison. Returns matched market pairs from the market_
 | `query` | string | No | Keyword search across matched market titles. |
 | `relations` | string | No | Comma-separated relation filter. Valid values: identity, subset, superset, overlap, disjoint. |
 | `minDifference` | number | No | Minimum price difference to include (0.0-1.0). |
+| `maxDifference` | number | No | Maximum price difference to include (0.0-1.0). Defaults to 0.20 when scanning opportunities with sort=priceDifference or minDifference > 0; pass 1 to include raw giant spreads. |
 | `category` | string | No | Filter both sides of the match by category. |
 | `limit` | integer | No | Maximum number of matched pairs to return. |
 | `minConfidence` | number | No | Minimum match confidence score (0.0-1.0). |
@@ -5271,6 +5272,7 @@ Bulk cross-venue price comparison. Returns matched market pairs from the market_
 | --- | --- | --- | --- |
 | `relations` | string | No | Comma-separated relation filter. Valid values: identity, subset, superset, overlap, disjoint. |
 | `minDifference` | number | No | Minimum price difference to include (0.0-1.0). |
+| `maxDifference` | number | No | Maximum price difference to include (0.0-1.0). Defaults to 0.20; pass 1 to include raw giant spreads. |
 | `category` | string | No | Filter both sides of the match by category. |
 | `limit` | integer | No | Maximum number of matched pairs to return. |
 | `minConfidence` | number | No | Minimum match confidence score (0.0-1.0). |


### PR DESCRIPTION
Auto-generated from hosted-pmxt. Updates OpenAPI paths, docs.json navigation, rate limit tables, and catalog venue list.