### PR TITLE
fix: initialize Probable order book resolver queues

### DIFF
--- a/core/scripts/generate-python-exchanges.js
+++ b/core/scripts/generate-python-exchanges.js
@@ -30,8 +30,8 @@ const OVERRIDES = {
 
 function toClassName(name) {
     return name
-        .split('-')
-        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .split(/[-_]/)
+        .map(part => part.toLowerCase() === 'us' ? 'US' : part.charAt(0).toUpperCase() + part.slice(1))
         .join('');
 }
 
@@ -244,7 +244,7 @@ init = init.replace(
 // Update the # Exchanges section in __all__
 const allEntries = classNames.map(n => `    "${n}",`).join('\n');
 init = init.replace(
-    /(    # Exchanges\n)([\s\S]*?)(    "Exchange",)/,
+    /(    # Exchanges\r?\n)([\s\S]*?)(    "Exchange",)/,
     `$1${allEntries}\n$3`
 );
 

--- a/core/src/exchanges/probable/websocket.ts
+++ b/core/src/exchanges/probable/websocket.ts
@@ -71,10 +71,7 @@ export class ProbableWebSocket {
 
         // Return a promise that resolves on the next orderbook update
         const dataPromise = new Promise<OrderBook>((resolve, reject) => {
-            if (!this.orderBookResolvers.has(tokenId)) {
-                this.orderBookResolvers.set(tokenId, []);
-            }
-            this.orderBookResolvers.get(tokenId)!.push({ resolve, reject });
+            this.getOrderBookQueue(tokenId).push({ resolve, reject });
         });
 
         return withWatchTimeout(
@@ -118,6 +115,17 @@ export class ProbableWebSocket {
             resolvers.forEach(r => r.resolve(orderBook));
             this.orderBookResolvers.set(tokenId, []);
         }
+    }
+
+    private getOrderBookQueue(tokenId: string): QueuedPromise<OrderBook>[] {
+        const resolvers = this.orderBookResolvers.get(tokenId);
+        if (resolvers) {
+            return resolvers;
+        }
+
+        const queue: QueuedPromise<OrderBook>[] = [];
+        this.orderBookResolvers.set(tokenId, queue);
+        return queue;
     }
 
     async close() {

--- a/core/test/pipeline/probable-websocket-resolvers.test.ts
+++ b/core/test/pipeline/probable-websocket-resolvers.test.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('Probable WebSocket resolver queues', () => {
+    it('does not rely on a non-null assertion when queueing order book watchers', () => {
+        const source = fs.readFileSync(
+            path.resolve(__dirname, '../../src/exchanges/probable/websocket.ts'),
+            'utf8',
+        );
+
+        expect(source).not.toMatch(/orderBookResolvers\.get\([^)]*\)!/);
+    });
+});

--- a/sdks/python/API_REFERENCE.md
+++ b/sdks/python/API_REFERENCE.md
@@ -386,14 +386,14 @@ Fetch the order book (bids/asks) for a specific outcome.
 **Signature:**
 
 ```python
-def fetch_order_book(outcome_id: str, limit: Optional[float] = None, params: Optional[Dict[str, Any]] = None) -> OrderBook:
+def fetch_order_book(outcome_id: str, limit: Optional[float] = None, params: Optional[FetchOrderBookParams] = None) -> OrderBook:
 ```
 
 **Parameters:**
 
 - `outcome_id` (str): The Outcome ID (outcomeId) or market slug
-- `limit` (float) - **Optional**: Max number of bid/ask levels to return (CCXT-style).
-- `params` (Dict[str, Any]) - **Optional**: Optional parameters:
+- `limit` (float) - **Optional**: Max number of bid/ask levels to return. For range
+- `params` ([FetchOrderBookParams](#fetchorderbookparams)) - **Optional**: Optional parameters:
 
 **Returns:** [OrderBook](#orderbook) - Order book with bids and asks. Returns OrderBook[] when
 
@@ -922,7 +922,7 @@ exchange.unwatch_address(address="0xabc...")
 
 
 ---
-### `test_dummy_method`
+### `close`
 
 Close all WebSocket connections and clean up resources.
 
@@ -930,19 +930,19 @@ Close all WebSocket connections and clean up resources.
 **Signature:**
 
 ```python
-def test_dummy_method(param: Optional[str] = None) -> str:
+def close() -> void:
 ```
 
 **Parameters:**
 
-- `param` (str) - **Optional**: param
+- None
 
-**Returns:** str - Result
+**Returns:** void - Result
 
 **Example:**
 
 ```python
-exchange.test_dummy_method(param="...")
+exchange.close()
 ```
 
 
@@ -1967,16 +1967,30 @@ limit: float # Maximum number of results to return
 ```
 
 ---
+### `FetchOrderBookParams`
+
+
+
+```python
+@dataclass
+class FetchOrderBookParams:
+side: str # Outcome side: 'yes' or 'no'. Required for exchanges like Limitless where the API returns a single orderbook per market.
+outcome: str # Outcome alias: 'yes' or 'no', or an outcome token ID. When set, the first argument is treated as a market ID and this value selects which outcome's order book to fetch. Accepts the literal strings 'yes'/'no' (resolved via a market lookup) or a raw outcome token ID.
+since: float # Unix timestamp (ms) — fetch a historical snapshot at or before this time, or the start of a range when combined with `until` (hosted API only).
+until: float # Unix timestamp (ms) — end of a historical range. When combined with `since`, returns an array of reconstructed L2 OrderBook snapshots between `since` and `until` (hosted API only).
+```
+
+---
 ### `TradesParams`
 
-Parameters for fetching trade history. No resolution parameter - trades are discrete events.
+
 
 ```python
 @dataclass
 class TradesParams:
 start: str # Start of the time range
 end: str # End of the time range
-limit: float # Maximum number of results to return
+limit: float # Maximum number of results to return (max {@link MAX_TRADES_LIMIT})
 ```
 
 ---

--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -17,7 +17,7 @@ Example:
 """
 
 from .client import Exchange
-from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, Polymarket_us, Hyperliquid, GeminiTitan, Mock, Router
+from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, PolymarketUS, Hyperliquid, GeminiTitan, Mock, Router
 from .router import Router
 from .server_manager import ServerManager
 from .errors import (
@@ -143,7 +143,7 @@ __all__ = [
     "Opinion",
     "Metaculus",
     "Smarkets",
-    "Polymarket_us",
+    "PolymarketUS",
     "Hyperliquid",
     "GeminiTitan",
     "Mock",

--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -365,8 +365,8 @@ class Smarkets(Exchange):
         )
 
 
-class Polymarket_us(Exchange):
-    """Polymarket_us exchange client."""
+class PolymarketUS(Exchange):
+    """PolymarketUS exchange client."""
 
     def __init__(
         self,
@@ -377,7 +377,7 @@ class Polymarket_us(Exchange):
         pmxt_api_key: Optional[str] = None,
     ):
         """
-        Initialize Polymarket_us client.
+        Initialize PolymarketUS client.
 
         Args:
             api_key: API key for authentication (optional)

--- a/sdks/python/scripts/generate-client-methods.js
+++ b/sdks/python/scripts/generate-client-methods.js
@@ -387,6 +387,41 @@ function buildPyReturnLines(config) {
 }
 
 function generatePyMethod(name, params, config, sf) {
+    if (name === 'fetchOrderBook') {
+        return [
+            `    def fetch_order_book(self, outcome_id: Union[str, "MarketOutcome"] = _UNSET, limit: Optional[float] = None, params: Optional[dict] = None, **kwargs) -> Union[OrderBook, List[OrderBook]]:`,
+            `        try:`,
+            `            args = []`,
+            `            if kwargs:`,
+            `                params = {**(params or {}), **kwargs}`,
+            `            outcome_id = _compat_id(outcome_id, kwargs)`,
+            `            args.append(_resolve_outcome_id(outcome_id))`,
+            `            if limit is not None:`,
+            `                args.append(limit)`,
+            `            if params is not None:`,
+            `                if limit is None:`,
+            `                    args.append(None)`,
+            `                args.append(params)`,
+            `            body: dict = {"args": args}`,
+            `            creds = self._get_credentials_dict()`,
+            `            if creds:`,
+            `                body["credentials"] = creds`,
+            `            url = f"{self._resolve_sidecar_host()}/api/{self.exchange_name}/fetchOrderBook"`,
+            `            headers = {"Content-Type": "application/json", "Accept": "application/json"}`,
+            `            headers.update(self._get_auth_headers())`,
+            `            response = self._fetch_with_retry(`,
+            `                lambda: self._api_client.call_api(method="POST", url=url, body=body, header_params=headers)`,
+            `            )`,
+            `            response.read()`,
+            `            data = self._handle_response(json.loads(response.data))`,
+            `            if isinstance(data, list):`,
+            `                return [_convert_order_book(d) for d in data]`,
+            `            return _convert_order_book(data)`,
+            `        except ApiException as e:`,
+            `            raise self._parse_api_exception(e) from None`,
+        ].join('\n');
+    }
+
     const snakeName = camelToSnake(name);
     const paramSig = buildPySignatureParams(params, sf);
     const hasParams = params.some(p => camelToSnake(p.name.getText(sf)) === 'params');

--- a/sdks/typescript/API_REFERENCE.md
+++ b/sdks/typescript/API_REFERENCE.md
@@ -389,14 +389,14 @@ Fetch the order book (bids/asks) for a specific outcome.
 **Signature:**
 
 ```typescript
-async fetchOrderBook(outcomeId: string, limit?: number, params?: Record<string, any>): Promise<OrderBook>
+async fetchOrderBook(outcomeId: string, limit?: number, params?: FetchOrderBookParams): Promise<OrderBook>
 ```
 
 **Parameters:**
 
 - `outcomeId` (string): The Outcome ID (outcomeId) or market slug
-- `limit` (number) - **Optional**: Max number of bid/ask levels to return (CCXT-style).
-- `params` (Record<string, any>) - **Optional**: Optional parameters:
+- `limit` (number) - **Optional**: Max number of bid/ask levels to return. For range
+- `params` ([FetchOrderBookParams](#fetchorderbookparams)) - **Optional**: Optional parameters:
 
 **Returns:** Promise<[OrderBook](#orderbook)> - Order book with bids and asks. Returns OrderBook[] when
 
@@ -925,7 +925,7 @@ await exchange.unwatchAddress("0xabc...")
 
 
 ---
-### `testDummyMethod`
+### `close`
 
 Close all WebSocket connections and clean up resources.
 
@@ -933,19 +933,19 @@ Close all WebSocket connections and clean up resources.
 **Signature:**
 
 ```typescript
-async testDummyMethod(param?: string): Promise<string>
+async close(): Promise<void>
 ```
 
 **Parameters:**
 
-- `param` (string) - **Optional**: param
+- None
 
-**Returns:** Promise<string> - Result
+**Returns:** Promise<void> - Result
 
 **Example:**
 
 ```typescript
-await exchange.testDummyMethod({ param: "..." })
+await exchange.close()
 ```
 
 
@@ -1968,15 +1968,29 @@ limit?: number; // Maximum number of results to return
 ```
 
 ---
+### `FetchOrderBookParams`
+
+
+
+```typescript
+interface FetchOrderBookParams {
+side?: string; // Outcome side: 'yes' or 'no'. Required for exchanges like Limitless where the API returns a single orderbook per market.
+outcome?: string; // Outcome alias: 'yes' or 'no', or an outcome token ID. When set, the first argument is treated as a market ID and this value selects which outcome's order book to fetch. Accepts the literal strings 'yes'/'no' (resolved via a market lookup) or a raw outcome token ID.
+since?: number; // Unix timestamp (ms) — fetch a historical snapshot at or before this time, or the start of a range when combined with `until` (hosted API only).
+until?: number; // Unix timestamp (ms) — end of a historical range. When combined with `since`, returns an array of reconstructed L2 OrderBook snapshots between `since` and `until` (hosted API only).
+}
+```
+
+---
 ### `TradesParams`
 
-Parameters for fetching trade history. No resolution parameter - trades are discrete events.
+
 
 ```typescript
 interface TradesParams {
 start?: string; // Start of the time range
 end?: string; // End of the time range
-limit?: number; // Maximum number of results to return
+limit?: number; // Maximum number of results to return (max {@link MAX_TRADES_LIMIT})
 }
 ```
 

--- a/sdks/typescript/scripts/generate-client-methods.js
+++ b/sdks/typescript/scripts/generate-client-methods.js
@@ -381,6 +381,44 @@ function buildReturnLines(config) {
 }
 
 function generateMethod(name, params, config, sf) {
+    if (name === 'fetchOrderBook') {
+        return [
+            `    async fetchOrderBook(outcomeId: string | MarketOutcome, limit?: number, params?: FetchOrderBookParams): Promise<OrderBook | OrderBook[]> {`,
+            `        await this.initPromise;`,
+            `        try {`,
+            `            const args: any[] = [];`,
+            `            args.push(resolveOutcomeId(outcomeId));`,
+            `            if (limit !== undefined) args.push(limit);`,
+            `            if (params !== undefined) {`,
+            `                if (limit === undefined) args.push(null);`,
+            `                args.push(params);`,
+            `            }`,
+            `            const response = await this.fetchWithRetry(\`\${this.resolveBaseUrl()}/api/\${this.exchangeName}/fetchOrderBook\`, {`,
+            `                method: 'POST',`,
+            `                headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },`,
+            `                body: JSON.stringify({ args, credentials: this.getCredentials() }),`,
+            `            });`,
+            `            if (!response.ok) {`,
+            `                const body = await response.json().catch(() => ({}));`,
+            `                if (body.error && typeof body.error === "object") {`,
+            `                    throw fromServerError(body.error);`,
+            `                }`,
+            `                throw new PmxtError(body.error?.message || response.statusText);`,
+            `            }`,
+            `            const json = await response.json();`,
+            `            const data = this.handleResponse(json);`,
+            `            if (Array.isArray(data)) {`,
+            `                return data.map(convertOrderBook);`,
+            `            }`,
+            `            return convertOrderBook(data);`,
+            `        } catch (error) {`,
+            `            if (error instanceof PmxtError) throw error;`,
+            `            throw new PmxtError(\`Failed to fetchOrderBook: \${error}\`);`,
+            `        }`,
+            `    }`,
+        ].join('\n');
+    }
+
     const sig = buildSignatureParams(params, sf);
     const argsCode = buildArgsLines(params, sf);
     const returnCode = buildReturnLines(config);


### PR DESCRIPTION
Fixes #264

## Changes
- Replace the guarded `orderBookResolvers.get(...)!` push path with an explicit queue initializer.
- Add a regression test so Probable websocket resolver queueing does not reintroduce the non-null assertion pattern.
- Include the current generator fixes from #509 so this PR passes the existing exchange/SDK drift gates while main is still out of sync.

## Verification
- `npm --workspace=pmxt-core test -- --runTestsByPath test/pipeline/probable-websocket-resolvers.test.ts --runInBand`
- `npx tsc -p core/tsconfig.json --noEmit`
- `node core/scripts/check-exchange-drift.js`
- `node sdks/typescript/scripts/generate-client-methods.js; git diff --exit-code sdks/typescript/pmxt/client.ts`
- `node sdks/python/scripts/generate-client-methods.js; git diff --exit-code sdks/python/pmxt/client.py`
- `python -m py_compile sdks/python/pmxt/_exchanges.py sdks/python/pmxt/__init__.py sdks/python/pmxt/client.py`
- `git diff --check`