### PR TITLE
fix: use dedicated volume24h field in gemini-titan normalizer

### DIFF
--- a/core/src/exchanges/gemini-titan/normalizer.ts
+++ b/core/src/exchanges/gemini-titan/normalizer.ts
@@ -109,7 +109,7 @@ export class GeminiNormalizer implements IExchangeNormalizer<GeminiRawEvent, Gem
             description: raw.description ?? '',
             slug: raw.slug ?? raw.ticker.toLowerCase(),
             markets: [],
-            volume24h: raw.volume ? parseFloat(raw.volume) : 0,
+            volume24h: raw.volume24h ? parseFloat(raw.volume24h) : 0,
             url: buildExchangeUrl(raw.ticker),
             category: raw.category,
             tags: raw.tags ?? [],

--- a/core/src/exchanges/gemini-titan/types.ts
+++ b/core/src/exchanges/gemini-titan/types.ts
@@ -53,6 +53,7 @@ export interface GeminiRawEvent {
     expiryDate?: string;
     contracts: GeminiRawContract[];
     volume?: string;
+    volume24h?: string;
     liquidity?: string;
     tags?: string[];
     subcategory?: Record<string, unknown>;


### PR DESCRIPTION
Fixes #444