### PR TITLE
fix: update Python sidecar package guidance

### DIFF
--- a/sdks/python/QUICKREF.py
+++ b/sdks/python/QUICKREF.py
@@ -5,7 +5,7 @@ Installation:
     pip install pmxt
 
 Start Server:
-    npm install -g pmxtjs
+    npm install -g pmxt-core
     pmxt-server
 
 Basic Usage:

--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -370,7 +370,7 @@ class Exchange(ABC):
             except Exception as e:
                 raise Exception(
                     f"Failed to start PMXT server: {e}\n\n"
-                    f"Please ensure 'pmxtjs' is installed: npm install -g pmxtjs\n"
+                    f"Please ensure 'pmxt-core' is installed: npm install -g pmxt-core\n"
                     f"Or start the server manually: pmxt-server"
                 )
 

--- a/sdks/python/tests/test_client_startup.py
+++ b/sdks/python/tests/test_client_startup.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_auto_start_failure_mentions_current_sidecar_package():
+    client_source = (
+        Path(__file__).resolve().parents[1] / "pmxt" / "client.py"
+    ).read_text(encoding="utf-8")
+
+    assert "Please ensure 'pmxt-core' is installed: npm install -g pmxt-core" in client_source
+    assert "Or start the server manually: pmxt-server" in client_source
+    assert "pmxtjs" not in client_source


### PR DESCRIPTION
## Summary

Closes #756.

The Python SDK auto-start failure message still pointed users at the old `pmxtjs` package. This updates the message to install `pmxt-core` while preserving the existing `pmxt-server` manual-start guidance, matching the current sidecar package naming used elsewhere in the project.

I also added a small source-level regression test under the Python SDK tests. It checks that the startup guidance includes `npm install -g pmxt-core`, keeps the `pmxt-server` hint, and no longer references `pmxtjs` in `pmxt/client.py`.

Verification:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_client_startup.py`

Plain `pytest tests/test_client_startup.py` is blocked in my local environment before collection by a globally installed pytest plugin import error for `evalcraft`; the focused test above passes with external plugin autoload disabled.
