### PR TITLE
feat: add sourceMetadata to UnifiedEvent and UnifiedMarket

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.47.0] - 2026-05-30
+
+### Added
+
+- **Core**: Optional `sourceMetadata` field on `UnifiedEvent` and `UnifiedMarket` (`Record<string, unknown>`) — captures venue-specific raw fields that are not promoted to first-class unified columns. Populated by every exchange normalizer (Kalshi, Polymarket, Polymarket US, Limitless, Smarkets, Opinion, Myriad, Probable, Metaculus, Baozi, Gemini-Titan, Hyperliquid, SuiBets) via a shared `buildSourceMetadata` helper at `core/src/utils/metadata.ts`. Includes recurring-series identifiers where the venue exposes them (Kalshi `series_ticker`/`series_title`, Polymarket `series`/`seriesSlug` when present, Opinion `collection`, Gemini-Titan `series`).
+
 ## [2.46.14] - 2026-05-26
 
 ### Fixed

--- a/core/COMPLIANCE.md
+++ b/core/COMPLIANCE.md
@@ -8,28 +8,28 @@ This document details the feature support and compliance status for each exchang
 
 ## Functions Status
 
-| Category | Function | Polymarket | Kalshi | Limitless | Probable | Baozi | Myriad | Opinion | Metaculus | SuiBets |
-| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| **Market Data** | `fetchMarkets` | Y | Y | Y | Y | Y | Y | Y | Y | Y |
-|  | `fetchEvents` | Y | Y | Y | Y | Y | Y | Y | Y | Y |
-|  | `fetchMarket` | Y | Y | Y | Y | Y | Y | Y | Y | Y |
-|  | `fetchEvent` | Y | Y | Y | Y | Y | Y | Y | Y | Y |
-| **Public Data** | `fetchOHLCV` | Y | Y | Y | Y | Y | Y | Y | - | - |
-|  | `fetchOrderBook` | Y | Y | Y | Y | Y | Y | Y | - | Y (emulated) |
-|  | `fetchTrades` | Y | Y | Y | Y | Y | Y | - | - | - |
-| **Private Data** | `fetchBalance` | Y | Y | Y | Y | Y | Y | - | - | - |
-|  | `fetchPositions` | Y | Y | Y | Y | Y | Y | Y | - | Y |
-|  | `fetchMyTrades` | Y | Y | Y | Y | - | Y | Y | - | - |
-| **Trading** | `createOrder` | Y | Y | Y | Y | Y | Y | Y | Y | - |
-|  | `cancelOrder` | Y | Y | Y | Y | Y | - | Y | Y | - |
-|  | `fetchOrder` | Y | Y | Y | Y | Y | - | Y | - | - |
-|  | `fetchOpenOrders` | Y | Y | Y | Y | Y | Y | Y | - | - |
-|  | `fetchClosedOrders` | - | Y | Y | - | - | - | Y | - | - |
-|  | `fetchAllOrders` | - | Y | Y | - | - | - | Y | - | - |
-| **Calculations** | `getExecutionPrice` | Y | Y | Y | Y | Y | Y | Y | - | - |
-|  | `getExecutionPriceDetailed` | Y | Y | Y | Y | Y | Y | Y | - | - |
-| **Real-time** | `watchOrderBook` | Y | Y | Y | Y | Y | Y | Y | - | - |
-|  | `watchTrades` | Y | Y | Y | - | - | Y | Y | - | - |
+| Category | Function | Polymarket | Kalshi | Limitless | Probable | Baozi | Myriad | Opinion | Metaculus |
+| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Market Data** | `fetchMarkets` | Y | Y | Y | Y | Y | Y | Y | Y |
+|  | `fetchEvents` | Y | Y | Y | Y | Y | Y | Y | Y |
+|  | `fetchMarket` | Y | Y | Y | Y | Y | Y | Y | Y |
+|  | `fetchEvent` | Y | Y | Y | Y | Y | Y | Y | Y |
+| **Public Data** | `fetchOHLCV` | Y | Y | Y | Y | Y | Y | Y | - |
+|  | `fetchOrderBook` | Y | Y | Y | Y | Y | Y | Y | - |
+|  | `fetchTrades` | Y | Y | Y | Y | Y | Y | - | - |
+| **Private Data** | `fetchBalance` | Y | Y | Y | Y | Y | Y | - | - |
+|  | `fetchPositions` | Y | Y | Y | Y | Y | Y | Y | - |
+|  | `fetchMyTrades` | Y | Y | Y | Y | - | Y | Y | - |
+| **Trading** | `createOrder` | Y | Y | Y | Y | Y | Y | Y | Y |
+|  | `cancelOrder` | Y | Y | Y | Y | Y | - | Y | Y |
+|  | `fetchOrder` | Y | Y | Y | Y | Y | - | Y | - |
+|  | `fetchOpenOrders` | Y | Y | Y | Y | Y | Y | Y | - |
+|  | `fetchClosedOrders` | - | Y | Y | - | - | - | Y | - |
+|  | `fetchAllOrders` | - | Y | Y | - | - | - | Y | - |
+| **Calculations** | `getExecutionPrice` | Y | Y | Y | Y | Y | Y | Y | - |
+|  | `getExecutionPriceDetailed` | Y | Y | Y | Y | Y | Y | Y | - |
+| **Real-time** | `watchOrderBook` | Y | Y | Y | Y | Y | Y | Y | - |
+|  | `watchTrades` | Y | Y | Y | - | - | Y | Y | - |
 
 ## Legend
 - **Y** - Supported

--- a/core/src/exchanges/baozi/normalizer.ts
+++ b/core/src/exchanges/baozi/normalizer.ts
@@ -58,6 +58,7 @@ export class BaoziNormalizer implements IExchangeNormalizer<BaoziRawMarket, Baoz
             image: market.image,
             category: market.category,
             tags: market.tags,
+            sourceMetadata: market.sourceMetadata,
         };
     }
 
@@ -84,6 +85,7 @@ export class BaoziNormalizer implements IExchangeNormalizer<BaoziRawMarket, Baoz
             image: m.image,
             category: m.category,
             tags: m.tags,
+            sourceMetadata: m.sourceMetadata,
         }));
     }
 

--- a/core/src/exchanges/baozi/utils.ts
+++ b/core/src/exchanges/baozi/utils.ts
@@ -3,6 +3,7 @@ import bs58 from 'bs58';
 import { createHash } from 'crypto';
 import { UnifiedMarket, MarketOutcome } from '../../types';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { clampBaoziPrice, normalizeBaoziOutcomes } from './price';
 
 // ---------------------------------------------------------------------------
@@ -365,6 +366,34 @@ export function parseRacePosition(data: Buffer | Uint8Array): BaoziRacePosition 
 }
 
 // ---------------------------------------------------------------------------
+// Promoted key sets — fields already represented by first-class unified columns.
+// These are excluded from sourceMetadata to avoid duplication.
+// ---------------------------------------------------------------------------
+
+// BaoziMarket fields promoted to unified columns:
+//   question -> title
+//   resolutionTime -> resolutionDate
+//   yesPool / noPool -> volume + liquidity
+//   status -> status
+// pubkey is promoted to marketId; outcomeLabels / outcomePools -> outcomes
+const BAOZI_BOOLEAN_PROMOTED_KEYS = [
+    'question',
+    'resolutionTime',
+    'yesPool',
+    'noPool',
+    'status',
+] as const;
+
+const BAOZI_RACE_PROMOTED_KEYS = [
+    'question',
+    'resolutionTime',
+    'totalPool',
+    'status',
+    'outcomeLabels',
+    'outcomePools',
+] as const;
+
+// ---------------------------------------------------------------------------
 // Mapping to Unified Types
 // ---------------------------------------------------------------------------
 
@@ -410,6 +439,10 @@ export function mapBooleanToUnified(market: BaoziMarket, pubkey: string): Unifie
         url: `https://baozi.bet/market/${pubkey}`,
         category: undefined,
         tags: [`tier:${layerName(market.layer)}`, 'solana', 'pari-mutuel'],
+        sourceMetadata: buildSourceMetadata(
+            market as unknown as Record<string, unknown>,
+            BAOZI_BOOLEAN_PROMOTED_KEYS,
+        ),
     };
 
     addBinaryOutcomes(um);
@@ -451,6 +484,10 @@ export function mapRaceToUnified(market: BaoziRaceMarket, pubkey: string): Unifi
         url: `https://baozi.bet/market/${pubkey}`,
         category: undefined,
         tags: [`tier:${layerName(market.layer)}`, 'solana', 'pari-mutuel', 'race'],
+        sourceMetadata: buildSourceMetadata(
+            market as unknown as Record<string, unknown>,
+            BAOZI_RACE_PROMOTED_KEYS,
+        ),
     };
 
     // For 2-outcome races, add binary convenience getters

--- a/core/src/exchanges/gemini-titan/normalizer.ts
+++ b/core/src/exchanges/gemini-titan/normalizer.ts
@@ -8,6 +8,7 @@ import {
 } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { toMarketId, toOutcomeId } from './utils';
 import { TICK_SIZE } from './config';
 import {
@@ -17,6 +18,32 @@ import {
     GeminiRawPosition,
     GeminiRawOrderBook,
 } from './types';
+
+// Raw GeminiRawEvent fields already promoted to first-class unified columns.
+// Omitted from sourceMetadata so we capture only vendor data the unified shape
+// would otherwise drop.
+const GEMINI_PROMOTED_EVENT_KEYS = [
+    'ticker',       // -> id
+    'title',
+    'description',
+    'slug',
+    'contracts',    // -> markets (nested child array, always omitted)
+    'volume24h',
+    'imageUrl',     // -> image
+    'category',
+    'tags',
+] as const;
+
+// Raw GeminiRawContract fields already promoted to first-class unified columns.
+const GEMINI_PROMOTED_CONTRACT_KEYS = [
+    'instrumentSymbol', // -> marketId, slug
+    'label',            // -> title
+    'description',
+    'ticker',           // parent event ticker feeds eventId
+    'status',           // -> status
+    'prices',           // -> outcomes prices
+    'expiryDate',       // -> resolutionDate
+] as const;
 
 // ----------------------------------------------------------------------------
 // Helpers
@@ -114,6 +141,10 @@ export class GeminiNormalizer implements IExchangeNormalizer<GeminiRawEvent, Gem
             category: raw.category,
             tags: raw.tags ?? [],
             image: raw.imageUrl,
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                GEMINI_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 
@@ -184,6 +215,11 @@ export class GeminiNormalizer implements IExchangeNormalizer<GeminiRawEvent, Gem
             tags.push(event.category);
         }
 
+        const seriesExtra: Record<string, unknown> = {};
+        if (event.series != null) {
+            seriesExtra['series'] = event.series;
+        }
+
         const um: UnifiedMarket = {
             marketId,
             eventId: event.ticker,
@@ -199,6 +235,11 @@ export class GeminiNormalizer implements IExchangeNormalizer<GeminiRawEvent, Gem
             tags,
             tickSize: TICK_SIZE,
             status: mapEventStatus(contract.status),
+            sourceMetadata: buildSourceMetadata(
+                contract as unknown as Record<string, unknown>,
+                GEMINI_PROMOTED_CONTRACT_KEYS,
+                Object.keys(seriesExtra).length > 0 ? seriesExtra : undefined,
+            ),
         };
 
         addBinaryOutcomes(um);

--- a/core/src/exchanges/hyperliquid/normalizer.ts
+++ b/core/src/exchanges/hyperliquid/normalizer.ts
@@ -13,6 +13,7 @@ import {
 import { IExchangeNormalizer } from '../interfaces';
 import { OHLCVParams } from '../../BaseExchange';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { toMarketId, toOutcomeId, toMidKey, decodeAssetId } from './utils';
 import { OUTCOME_ASSET_BASE } from './config';
 import {
@@ -28,6 +29,25 @@ import {
     HyperliquidRawOutcomeMeta,
     HyperliquidRawMid,
 } from './fetcher';
+
+// Raw Hyperliquid outcome fields already promoted to first-class Unified columns —
+// excluded from sourceMetadata so we capture only what the unified shape would drop.
+const HL_PROMOTED_MARKET_KEYS = [
+    'outcome',      // -> marketId
+    'name',         // -> title
+    'description',  // -> description
+    'sideSpecs',    // -> outcomes (labels)
+] as const;
+
+// Raw Hyperliquid question fields already promoted to first-class Unified columns.
+// namedOutcomes is omitted as well — it is the child-markets array and must not
+// be duplicated in metadata.
+const HL_PROMOTED_EVENT_KEYS = [
+    'question',       // -> id / eventId
+    'name',           // -> title
+    'description',    // -> description
+    'namedOutcomes',  // -> markets (child-markets array)
+] as const;
 
 // ----------------------------------------------------------------------------
 // Helpers
@@ -220,6 +240,10 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
             tags,
             tickSize: 0.001,
             status: 'active',
+            sourceMetadata: buildSourceMetadata(
+                outcome as unknown as Record<string, unknown>,
+                HL_PROMOTED_MARKET_KEYS,
+            ),
         };
 
         addBinaryOutcomes(um);
@@ -255,6 +279,10 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
             url: buildEventUrl(raw.question),
             category: underlying ? 'Crypto' : undefined,
             tags,
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                HL_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 

--- a/core/src/exchanges/kalshi/normalizer.ts
+++ b/core/src/exchanges/kalshi/normalizer.ts
@@ -2,8 +2,23 @@ import { OHLCVParams } from '../../BaseExchange';
 import { UnifiedMarket, UnifiedEvent, PriceCandle, OrderBook, Trade, UserTrade, Position, Balance, MarketOutcome } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { fromKalshiCents, invertKalshiUnified } from './price';
 import { KalshiRawEvent, KalshiRawMarket, KalshiRawCandlestick, KalshiRawTrade, KalshiRawFill, KalshiRawOrder, KalshiRawPosition, KalshiRawOrderBookFp } from './fetcher';
+
+// Raw Kalshi fields already promoted to first-class Unified columns — excluded
+// from sourceMetadata so we capture only what the unified shape would drop.
+const KALSHI_PROMOTED_EVENT_KEYS = [
+    'event_ticker', 'title', 'markets', 'category', 'image_url', 'tags',
+] as const;
+
+const KALSHI_PROMOTED_MARKET_KEYS = [
+    'ticker', 'title', 'rules_primary', 'rules_secondary', 'expiration_time',
+    'volume_24h_fp', 'volume_24h', 'volume', 'volume_fp',
+    'liquidity_dollars', 'liquidity', 'open_interest_fp', 'open_interest',
+    'status', 'last_price_dollars', 'previous_price_dollars',
+    'yes_ask_dollars', 'yes_bid_dollars', 'last_price', 'yes_ask', 'yes_bid',
+] as const;
 
 export class KalshiNormalizer implements IExchangeNormalizer<KalshiRawEvent, KalshiRawEvent> {
 
@@ -92,6 +107,15 @@ export class KalshiNormalizer implements IExchangeNormalizer<KalshiRawEvent, Kal
             category: event.category,
             tags: unifiedTags,
             status: this.cleanLabel(market.status) || undefined,
+            // series_ticker/series_title live on the parent event, not the raw
+            // market, and aren't promoted to a column — attach them here so
+            // markets are queryable by series. event_ticker is omitted (already
+            // promoted to eventId).
+            sourceMetadata: buildSourceMetadata(
+                market as unknown as Record<string, unknown>,
+                KALSHI_PROMOTED_MARKET_KEYS,
+                { series_ticker: event.series_ticker, series_title: event.series_title },
+            ),
         } as UnifiedMarket;
 
         addBinaryOutcomes(um);
@@ -117,6 +141,12 @@ export class KalshiNormalizer implements IExchangeNormalizer<KalshiRawEvent, Kal
             image: raw.image_url ?? undefined,
             category: raw.category,
             tags: raw.tags || [],
+            // Keeps non-promoted event fields (series_ticker, series_title,
+            // sub_title, strike_period, ...); raw markets array is promoted.
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                KALSHI_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 

--- a/core/src/exchanges/limitless/normalizer.ts
+++ b/core/src/exchanges/limitless/normalizer.ts
@@ -2,6 +2,7 @@ import { OHLCVParams } from '../../BaseExchange';
 import { UnifiedMarket, UnifiedEvent, PriceCandle, OrderBook, Trade, UserTrade, Position, Balance } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
 import { mapMarketToUnified } from './utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import {
     LimitlessRawMarket,
     LimitlessRawEvent,
@@ -9,6 +10,15 @@ import {
     LimitlessRawOrderBook,
     LimitlessRawTrade,
 } from './fetcher';
+
+// Raw Limitless event fields already promoted to first-class Unified columns —
+// excluded from sourceMetadata so we capture only what the unified shape drops.
+const LIMITLESS_PROMOTED_EVENT_KEYS = [
+    'slug', 'title', 'question', 'description',
+    'logo',
+    'categories', 'tags',
+    'markets',
+] as const;
 
 // Limitless uses USDC with 6 decimals
 const USDC_DECIMALS = 6;
@@ -59,6 +69,10 @@ export class LimitlessNormalizer implements IExchangeNormalizer<LimitlessRawMark
             image: raw.logo || `https://limitless.exchange/api/og?slug=${raw.slug}`,
             category: raw.categories?.[0],
             tags: raw.tags || [],
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                LIMITLESS_PROMOTED_EVENT_KEYS,
+            ),
         } as UnifiedEvent;
     }
 

--- a/core/src/exchanges/limitless/utils.ts
+++ b/core/src/exchanges/limitless/utils.ts
@@ -1,7 +1,24 @@
 import { UnifiedMarket, MarketOutcome, CandleInterval } from '../../types';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 
 export const DEFAULT_LIMITLESS_API_URL = 'https://api.limitless.exchange';
+
+// Raw Limitless market fields already promoted to first-class Unified columns —
+// excluded from sourceMetadata so we capture only what the unified shape drops.
+// Also excludes __pmxt* internal injection keys (not raw vendor data).
+const LIMITLESS_PROMOTED_MARKET_KEYS = [
+    'slug', 'title', 'question', 'description',
+    'tokens', 'prices',
+    'expirationTimestamp',
+    'volumeFormatted', 'volume',
+    'logo',
+    'categories', 'tags',
+    'expired', 'status',
+    'markets',
+    '__pmxtEventId', '__pmxtEventTitle', '__pmxtEventDescription',
+    '__pmxtCategories', '__pmxtTags',
+] as const;
 
 export interface LimitlessMarketContext {
     eventId?: string;
@@ -84,6 +101,10 @@ export function mapMarketToUnified(market: any, context: LimitlessMarketContext 
         category: market.categories?.[0] || resolvedContext.categories?.[0],
         tags: market.tags || resolvedContext.tags || [],
         status,
+        sourceMetadata: buildSourceMetadata(
+            market as unknown as Record<string, unknown>,
+            LIMITLESS_PROMOTED_MARKET_KEYS,
+        ),
     } as UnifiedMarket;
 
     addBinaryOutcomes(um);

--- a/core/src/exchanges/metaculus/fetchEvents.ts
+++ b/core/src/exchanges/metaculus/fetchEvents.ts
@@ -1,7 +1,8 @@
 import { EventFetchParams } from "../../BaseExchange";
 import { UnifiedEvent } from "../../types";
-import { expandPost } from "./utils";
+import { expandPost, METACULUS_PROMOTED_EVENT_KEYS } from "./utils";
 import { metaculusErrorMapper } from "./errors";
+import { buildSourceMetadata } from "../../utils/metadata";
 
 type CallApi = (
     operationId: string,
@@ -85,6 +86,10 @@ function postToEvent(post: any): UnifiedEvent | null {
                     : post.projects.category[0]?.name
                 : undefined,
         tags: markets[0]?.tags ?? [],
+        sourceMetadata: buildSourceMetadata(
+            post as unknown as Record<string, unknown>,
+            METACULUS_PROMOTED_EVENT_KEYS,
+        ),
     };
 }
 

--- a/core/src/exchanges/metaculus/utils.ts
+++ b/core/src/exchanges/metaculus/utils.ts
@@ -1,5 +1,35 @@
 import { UnifiedMarket, MarketOutcome } from "../../types";
 import { addBinaryOutcomes } from "../../utils/market-utils";
+import { buildSourceMetadata } from "../../utils/metadata";
+
+// Raw Metaculus Post fields already promoted to first-class UnifiedMarket columns
+// — excluded from sourceMetadata so we capture only what the unified shape drops.
+const METACULUS_PROMOTED_MARKET_KEYS = [
+    // identity / slug
+    'id', 'slug', 'url_title',
+    // title
+    'title',
+    // description lives inside question / group_of_questions — those are excluded below
+    // resolution timing -> resolutionDate
+    'scheduled_resolve_time', 'scheduled_close_time', 'actual_close_time',
+    // forecaster count -> liquidity / openInterest
+    'nr_forecasters',
+    // child objects whose fields are promoted individually
+    'question', 'group_of_questions',
+    // project sub-tree fields that map to image / category / tags / eventId
+    'projects',
+    // status -> mapStatus
+    'status',
+] as const;
+
+// Raw Metaculus Post fields already promoted to first-class UnifiedEvent columns.
+export const METACULUS_PROMOTED_EVENT_KEYS = [
+    'id', 'slug', 'url_title',
+    'title',
+    'question', 'group_of_questions',
+    'projects',
+    'status',
+] as const;
 
 /**
  * Base URL passed to parseOpenApiSpec to override the spec's servers[0].url.
@@ -196,7 +226,7 @@ function buildOutcomes(question: any, postId: string, medianProb: number): Marke
  * @param eventId   Optional parent event ID (tournament slug) to override
  *                  the value derived from post.projects.tournament.
  */
-export function mapMarketToUnified(post: any, eventId?: string): UnifiedMarket | null {
+export function mapMarketToUnified(post: any, eventId?: string, groupPostId?: number): UnifiedMarket | null {
     if (!post || !post.id) return null;
 
     // Group-of-questions posts have no top-level question -- they must be
@@ -264,6 +294,11 @@ export function mapMarketToUnified(post: any, eventId?: string): UnifiedMarket |
         image: post.projects?.default_project?.header_image ?? undefined,
         category,
         tags,
+        sourceMetadata: buildSourceMetadata(
+            post as unknown as Record<string, unknown>,
+            METACULUS_PROMOTED_MARKET_KEYS,
+            groupPostId !== undefined ? { group_post_id: groupPostId } : undefined,
+        ),
     };
 
     addBinaryOutcomes(um);
@@ -309,7 +344,7 @@ function mapGroupPostToMarkets(post: any, eventId?: string): UnifiedMarket[] {
             status: post.status,
         };
 
-        const market = mapMarketToUnified(syntheticPost, groupEventId);
+        const market = mapMarketToUnified(syntheticPost, groupEventId, Number(parentPostId));
         if (market) {
             // Tag each outcome with the parent group post ID for traceability
             for (const outcome of market.outcomes) {

--- a/core/src/exchanges/myriad/normalizer.ts
+++ b/core/src/exchanges/myriad/normalizer.ts
@@ -2,9 +2,22 @@ import { OHLCVParams } from '../../BaseExchange';
 import { UnifiedMarket, UnifiedEvent, PriceCandle, OrderBook, Trade, UserTrade, Position, Balance, CandleInterval, MarketOutcome } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { MyriadRawMarket, MyriadRawQuestion, MyriadRawTradeEvent, MyriadRawPortfolioItem } from './fetcher';
 import { resolveMyriadPrice } from './price';
 import { mapMarketState } from './utils';
+
+// Raw Myriad fields already promoted to first-class Unified columns — excluded
+// from sourceMetadata so we capture only what the unified shape would drop.
+const MYRIAD_PROMOTED_MARKET_KEYS = [
+    'id', 'networkId', 'title', 'description', 'slug', 'imageUrl',
+    'expiresAt', 'volume24h', 'volume', 'liquidity', 'eventId',
+    'topics', 'outcomes', 'state',
+] as const;
+
+const MYRIAD_PROMOTED_EVENT_KEYS = [
+    'id', 'title', 'markets',
+] as const;
 
 function selectTimeframe(interval: CandleInterval): string {
     switch (interval) {
@@ -51,6 +64,10 @@ export class MyriadNormalizer implements IExchangeNormalizer<MyriadRawMarket, My
             image: raw.imageUrl,
             tags: raw.topics || [],
             status,
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                MYRIAD_PROMOTED_MARKET_KEYS,
+            ),
         } as UnifiedMarket;
 
         addBinaryOutcomes(um);
@@ -105,6 +122,11 @@ export class MyriadNormalizer implements IExchangeNormalizer<MyriadRawMarket, My
                 ? markets.reduce((sum, m) => sum + (m.volume ?? 0), 0)
                 : undefined,
             url: `https://myriad.markets`,
+            // Keeps non-promoted question fields; raw markets array is promoted.
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                MYRIAD_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 

--- a/core/src/exchanges/myriad/utils.ts
+++ b/core/src/exchanges/myriad/utils.ts
@@ -1,5 +1,18 @@
 import { UnifiedMarket, UnifiedEvent, MarketOutcome } from '../../types';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
+
+// Raw Myriad fields already promoted to first-class Unified columns — excluded
+// from sourceMetadata so we capture only what the unified shape would drop.
+const MYRIAD_PROMOTED_MARKET_KEYS = [
+    'id', 'networkId', 'title', 'description', 'slug', 'imageUrl',
+    'expiresAt', 'volume24h', 'volume', 'liquidity', 'eventId',
+    'topics', 'outcomes', 'state',
+] as const;
+
+const MYRIAD_PROMOTED_EVENT_KEYS = [
+    'id', 'title', 'markets',
+] as const;
 
 export const DEFAULT_BASE_URL = 'https://api-v2.myriadprotocol.com';
 
@@ -76,6 +89,10 @@ export function mapMarketToUnified(market: any): UnifiedMarket | null {
         url: `https://myriad.markets/markets/${market.slug || market.id}`,
         image: market.imageUrl,
         tags: market.topics || [],
+        sourceMetadata: buildSourceMetadata(
+            market as unknown as Record<string, unknown>,
+            MYRIAD_PROMOTED_MARKET_KEYS,
+        ),
     } as UnifiedMarket;
 
     addBinaryOutcomes(um);
@@ -100,6 +117,11 @@ export function mapQuestionToEvent(question: any): UnifiedEvent | null {
         volume24h: markets.reduce((sum, m) => sum + m.volume24h, 0),
         volume: markets.some(m => m.volume !== undefined) ? markets.reduce((sum, m) => sum + (m.volume ?? 0), 0) : undefined,
         url: `https://myriad.markets`,
+        // Keeps non-promoted question fields; raw markets array is promoted.
+        sourceMetadata: buildSourceMetadata(
+            question as unknown as Record<string, unknown>,
+            MYRIAD_PROMOTED_EVENT_KEYS,
+        ),
     };
 
     return unifiedEvent;

--- a/core/src/exchanges/opinion/normalizer.ts
+++ b/core/src/exchanges/opinion/normalizer.ts
@@ -12,6 +12,7 @@ import {
 } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { parseNumStr, mapOrderStatus, toMillis, intervalToMs } from './utils';
 import {
     OpinionRawMarket,
@@ -23,6 +24,24 @@ import {
     OpinionRawPosition,
     OpinionRawOrder,
 } from './fetcher';
+
+// ---------------------------------------------------------------------------
+// Raw Opinion fields already promoted to first-class Unified columns — omit
+// from sourceMetadata so we capture only what the unified shape would drop.
+// ---------------------------------------------------------------------------
+
+// Fields promoted on a market or child-market payload.
+const OPINION_PROMOTED_MARKET_KEYS = [
+    'marketId', 'marketTitle', 'rules', 'slug',
+    'volume', 'volume24h', 'cutoffAt',
+    'yesTokenId', 'noTokenId',
+] as const;
+
+// Fields promoted on the parent (event-level) payload.
+const OPINION_PROMOTED_EVENT_KEYS = [
+    'marketId', 'marketTitle', 'rules', 'slug',
+    'volume', 'volume24h', 'childMarkets',
+] as const;
 
 // ---------------------------------------------------------------------------
 // Opinion Trade Normalizer
@@ -97,6 +116,13 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
             volume24h,
             volume: totalVolume,
             url: `https://www.opinion.trade/market/${raw.slug || raw.marketId}`,
+            // collection carries series/recurring identifier (title, symbol,
+            // frequency, current period, next periods) — not a unified column.
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                OPINION_PROMOTED_EVENT_KEYS,
+                raw.collection ? { collection: raw.collection } : undefined,
+            ),
         };
     }
 
@@ -317,6 +343,10 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
             volume: parseNumStr(raw.volume),
             liquidity: 0,
             url: `https://www.opinion.trade/market/${raw.slug || raw.marketId}`,
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                OPINION_PROMOTED_MARKET_KEYS,
+            ),
         };
 
         addBinaryOutcomes(market);
@@ -370,6 +400,16 @@ export class OpinionNormalizer implements IExchangeNormalizer<OpinionRawMarket, 
             volume: parseNumStr(child.volume),
             liquidity: 0,
             url: `https://www.opinion.trade/market/${child.slug || child.marketId}`,
+            // parentMarketId links the child back to its categorical parent;
+            // collection carries the series/recurring context from the parent.
+            sourceMetadata: buildSourceMetadata(
+                child as unknown as Record<string, unknown>,
+                OPINION_PROMOTED_MARKET_KEYS,
+                {
+                    parentMarketId: parent.marketId,
+                    ...(parent.collection ? { collection: parent.collection } : {}),
+                },
+            ),
         };
 
         addBinaryOutcomes(market);

--- a/core/src/exchanges/polymarket/normalizer.ts
+++ b/core/src/exchanges/polymarket/normalizer.ts
@@ -1,6 +1,7 @@
 import { OHLCVParams } from '../../BaseExchange';
 import { UnifiedMarket, UnifiedEvent, PriceCandle, OrderBook, Trade, UserTrade, Position } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { mapMarketToUnified, mapIntervalToFidelity } from './utils';
 import {
     PolymarketRawEvent,
@@ -9,6 +10,15 @@ import {
     PolymarketRawTrade,
     PolymarketRawPosition,
 } from './fetcher';
+
+// Raw Polymarket Gamma event fields already promoted to first-class Unified
+// columns — excluded from sourceMetadata so we capture only what the unified
+// shape would otherwise drop.
+const POLYMARKET_PROMOTED_EVENT_KEYS = [
+    'id', 'slug', 'title', 'description', 'image', 'category', 'tags',
+    // 'markets' is the child-markets array — promoted to UnifiedEvent.markets
+    'markets',
+] as const;
 
 export class PolymarketNormalizer implements IExchangeNormalizer<PolymarketRawEvent, PolymarketRawEvent> {
 
@@ -51,6 +61,15 @@ export class PolymarketNormalizer implements IExchangeNormalizer<PolymarketRawEv
             image: (raw.image as string) || `https://polymarket.com/api/og?slug=${raw.slug}`,
             category: (raw.category as string) || raw.tags?.[0]?.label,
             tags: raw.tags?.map((t: any) => t.label) || [],
+            // Keeps non-promoted Gamma event fields (e.g. active, closed, and
+            // any other vendor fields not surfaced as first-class columns).
+            // NOTE: Polymarket "series" data lives on a separate Gamma /series
+            // endpoint — it is NOT present in the event payload and therefore
+            // requires a separate /series fetch+join to populate here.
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                POLYMARKET_PROMOTED_EVENT_KEYS,
+            ),
         } as UnifiedEvent;
     }
 

--- a/core/src/exchanges/polymarket/utils.ts
+++ b/core/src/exchanges/polymarket/utils.ts
@@ -1,6 +1,28 @@
 import { UnifiedMarket, MarketOutcome, CandleInterval } from '../../types';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { logger } from '../../utils/logger';
+
+// Raw Polymarket Gamma market fields already promoted to first-class Unified
+// columns — excluded from sourceMetadata so we capture only what the unified
+// shape would otherwise drop.
+const POLYMARKET_PROMOTED_MARKET_KEYS = [
+    'id', 'question', 'description',
+    // outcomes array and prices are promoted to UnifiedMarket.outcomes
+    'outcomes', 'outcomePrices', 'clobTokenIds',
+    // resolution date fields
+    'endDate', 'end_date_iso', 'endDateIso',
+    // volume, liquidity, openInterest
+    'volume24hr', 'volume_24h', 'volume', 'liquidity', 'rewards',
+    'openInterest', 'open_interest',
+    // image, slug, contractAddress, tickSize, status fields
+    'image', 'slug',
+    'orderPriceMinTickSize',
+    'conditionId',
+    'active', 'closed', 'archived',
+    // parent event back-reference — eventId already promoted to UnifiedMarket.eventId
+    'events',
+] as const;
 
 export const GAMMA_API_URL = process.env.POLYMARKET_GAMMA_URL || 'https://gamma-api.polymarket.com/events';
 export const GAMMA_SEARCH_URL = process.env.POLYMARKET_GAMMA_SEARCH_URL || 'https://gamma-api.polymarket.com/public-search';
@@ -108,6 +130,16 @@ export function mapMarketToUnified(event: any, market: any, options: { useQuesti
         tickSize: market.orderPriceMinTickSize != null ? Number(market.orderPriceMinTickSize) : undefined,
         status,
         contractAddress: typeof market.conditionId === 'string' && market.conditionId.length > 0 ? market.conditionId : undefined,
+        // Keeps non-promoted Gamma market fields (e.g. groupItemTitle,
+        // oneDayPriceChange, and any other vendor fields not surfaced as
+        // first-class columns).
+        // NOTE: Polymarket "series" data lives on a separate Gamma /series
+        // endpoint — it is NOT present in the market payload and requires a
+        // separate /series fetch+join to populate here.
+        sourceMetadata: buildSourceMetadata(
+            market as unknown as Record<string, unknown>,
+            POLYMARKET_PROMOTED_MARKET_KEYS,
+        ),
     } as UnifiedMarket;
 
     addBinaryOutcomes(um);

--- a/core/src/exchanges/polymarket_us/normalizer.ts
+++ b/core/src/exchanges/polymarket_us/normalizer.ts
@@ -22,7 +22,22 @@ import {
     UserTrade,
 } from '../../types';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { fromAmount, fromLongSidePrice } from './price';
+
+// Raw Polymarket US fields already promoted to first-class Unified columns —
+// excluded from sourceMetadata so we capture only what the unified shape drops.
+const POLYMARKET_US_PROMOTED_EVENT_KEYS = [
+    'slug', 'title', 'description', 'category', 'tags', 'volume', 'markets',
+] as const;
+
+// marketSides and outcomePrices feed the outcomes array and are therefore
+// treated as promoted. orderPriceMinTickSize maps to tickSize.
+const POLYMARKET_US_PROMOTED_MARKET_KEYS = [
+    'slug', 'question', 'title', 'description', 'category', 'tags',
+    'endDate', 'marketSides', 'outcomePrices', 'orderPriceMinTickSize',
+    'eventSlug', 'volume', 'liquidity',
+] as const;
 
 // ----------------------------------------------------------------------------
 // Runtime-accurate shapes
@@ -335,6 +350,10 @@ export class PolymarketUSNormalizer {
             url: buildEventUrl(real.slug),
             category,
             tags,
+            sourceMetadata: buildSourceMetadata(
+                real as unknown as Record<string, unknown>,
+                POLYMARKET_US_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 
@@ -373,6 +392,10 @@ export class PolymarketUSNormalizer {
             tickSize: typeof market.orderPriceMinTickSize === 'number'
                 ? market.orderPriceMinTickSize
                 : undefined,
+            sourceMetadata: buildSourceMetadata(
+                market as unknown as Record<string, unknown>,
+                POLYMARKET_US_PROMOTED_MARKET_KEYS,
+            ),
         };
 
         addBinaryOutcomes(um);

--- a/core/src/exchanges/probable/utils.ts
+++ b/core/src/exchanges/probable/utils.ts
@@ -1,5 +1,17 @@
 import { UnifiedMarket, UnifiedEvent, MarketOutcome } from '../../types';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
+
+// Raw Probable fields already promoted to first-class Unified columns — omitted
+// from sourceMetadata so we capture only what the unified shape would drop.
+const PROBABLE_PROMOTED_EVENT_KEYS = [
+    'id', 'title', 'description', 'slug', 'icon', 'image', 'category', 'tags', 'markets',
+] as const;
+
+const PROBABLE_PROMOTED_MARKET_KEYS = [
+    'id', 'question', 'title', 'description', 'slug', 'endDate',
+    'volume24hr', 'volume', 'liquidity', 'icon', 'category', 'tags', 'tokens', 'event_id',
+] as const;
 
 export const DEFAULT_BASE_URL = 'https://market-api.probable.markets';
 export const SEARCH_PATH = '/public/api/v1/public-search/';
@@ -52,6 +64,13 @@ export function mapMarketToUnified(market: any, event?: any): UnifiedMarket | nu
         image: market.icon || event?.icon || event?.image || undefined,
         category: event?.category || market.category || undefined,
         tags: market.tags || event?.tags || [],
+        sourceMetadata: buildSourceMetadata(
+            market as unknown as Record<string, unknown>,
+            PROBABLE_PROMOTED_MARKET_KEYS,
+            // event_slug is not promoted to any first-class column — attach it so
+            // markets remain queryable by their parent event slug.
+            event ? { event_slug: event.slug } : undefined,
+        ),
     } as UnifiedMarket;
 
     addBinaryOutcomes(um);
@@ -81,6 +100,12 @@ export function mapEventToUnified(event: any): UnifiedEvent | null {
         image: event.icon || event.image || undefined,
         category: event.category || undefined,
         tags: event.tags || [],
+        // Captures non-promoted event fields; markets child array is already
+        // promoted to the unified markets column so it is excluded.
+        sourceMetadata: buildSourceMetadata(
+            event as unknown as Record<string, unknown>,
+            PROBABLE_PROMOTED_EVENT_KEYS,
+        ),
     };
 
     return unifiedEvent;

--- a/core/src/exchanges/smarkets/normalizer.ts
+++ b/core/src/exchanges/smarkets/normalizer.ts
@@ -1,6 +1,7 @@
 import { UnifiedMarket, UnifiedEvent, OrderBook, Trade, UserTrade, Position, Balance, MarketOutcome, Order } from '../../types';
 import { IExchangeNormalizer } from '../interfaces';
 import { addBinaryOutcomes } from '../../utils/market-utils';
+import { buildSourceMetadata } from '../../utils/metadata';
 import { fromBasisPoints, fromQuantityUnits } from './price';
 import {
     SmarketsRawEventWithMarkets,
@@ -13,6 +14,20 @@ import {
     SmarketsRawVolume,
     SmarketsRawBalance,
 } from './fetcher';
+
+// Raw Smarkets event fields already promoted to first-class Unified columns —
+// excluded from sourceMetadata so we capture only vendor data not in the
+// unified shape.
+const SMARKETS_PROMOTED_EVENT_KEYS = [
+    'id', 'name', 'description', 'slug', 'full_slug',
+    'start_datetime', 'end_date',
+] as const;
+
+// Raw Smarkets market fields already promoted to first-class Unified columns.
+const SMARKETS_PROMOTED_MARKET_KEYS = [
+    'id', 'event_id', 'name', 'slug', 'description',
+    'category', 'categories',
+] as const;
 
 // ----------------------------------------------------------------------------
 // Helpers
@@ -123,6 +138,12 @@ export class SmarketsNormalizer implements IExchangeNormalizer<SmarketsRawEventW
             url: buildEventUrl(event),
             category,
             tags,
+            // event_id is promoted to eventId; parent_id lives on the raw event
+            // (not a recurring/series market field), so no extra is needed.
+            sourceMetadata: buildSourceMetadata(
+                market as unknown as Record<string, unknown>,
+                SMARKETS_PROMOTED_MARKET_KEYS,
+            ),
         } as UnifiedMarket;
 
         addBinaryOutcomes(um);
@@ -148,6 +169,13 @@ export class SmarketsNormalizer implements IExchangeNormalizer<SmarketsRawEventW
             url: buildEventUrl(raw.event),
             category,
             tags: category ? [category] : [],
+            // Captures non-promoted event fields: state, type, parent_id,
+            // start_date, created, modified, bettable, hidden, inplay_enabled,
+            // short_name, seo_description, special_rules, chart_time_period, etc.
+            sourceMetadata: buildSourceMetadata(
+                raw.event as unknown as Record<string, unknown>,
+                SMARKETS_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 

--- a/core/src/exchanges/suibets/normalizer.ts
+++ b/core/src/exchanges/suibets/normalizer.ts
@@ -1,6 +1,7 @@
 import { IExchangeNormalizer } from '../interfaces';
 import { UnifiedMarket, UnifiedEvent, Position } from '../../types';
 import { SuibetsRawOffer, SuibetsRawEvent } from './fetcher';
+import { buildSourceMetadata } from '../../utils/metadata';
 import {
     impliedProbability,
     takerProbability,
@@ -10,6 +11,21 @@ import {
     toOutcomeId,
     mapStatus,
 } from './utils';
+
+// Raw SuiBets offer fields already promoted to first-class UnifiedMarket columns.
+// Omit these from sourceMetadata to capture only vendor-specific data not
+// represented by the unified shape.
+const SUIBETS_PROMOTED_OFFER_KEYS = [
+    'id', 'matchId', 'matchName', 'homeTeam', 'awayTeam',
+    'creatorOdds', 'creatorStake', 'remainingStake', 'totalMatched',
+    'matchDate', 'expiresAt', 'status', 'onchainOfferId',
+    'leagueName', 'sport', 'isOnchain',
+] as const;
+
+// Raw SuiBets event fields already promoted to first-class UnifiedEvent columns.
+const SUIBETS_PROMOTED_EVENT_KEYS = [
+    'id', 'name', 'homeTeam', 'awayTeam', 'sport', 'leagueName', 'offers',
+] as const;
 
 function liquidity(offer: SuibetsRawOffer): number {
     const remaining = offer.remainingStake ?? offer.creatorStake;
@@ -71,6 +87,12 @@ export class SuibetsNormalizer implements IExchangeNormalizer<SuibetsRawOffer, S
             contractAddress: raw.onchainOfferId,
             yes: creatorOutcome,
             no: takerOutcome,
+            // Retains creatorWallet, creatorTeam, takerStake, currency \u2014 fields
+            // that are vendor-specific and not promoted to any unified column.
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                SUIBETS_PROMOTED_OFFER_KEYS,
+            ),
         };
 
         return market;
@@ -103,6 +125,12 @@ export class SuibetsNormalizer implements IExchangeNormalizer<SuibetsRawOffer, S
             url: 'https://suibets.replit.app/p2p',
             category: 'Sports',
             tags: ['Sports', 'P2P', 'Sui', raw.sport, raw.leagueName].filter((t): t is string => Boolean(t)),
+            // Retains matchDate and status \u2014 event-level fields not promoted to
+            // any first-class UnifiedEvent column.
+            sourceMetadata: buildSourceMetadata(
+                raw as unknown as Record<string, unknown>,
+                SUIBETS_PROMOTED_EVENT_KEYS,
+            ),
         };
     }
 

--- a/core/src/server/openapi.yaml
+++ b/core/src/server/openapi.yaml
@@ -2902,6 +2902,13 @@ components:
         contractAddress:
           type: string
           description: 'On-chain contract / condition identifier where applicable (Polymarket conditionId, etc.).'
+        sourceMetadata:
+          type: object
+          additionalProperties: {}
+          description: >-
+            Raw venue-specific metadata not captured by first-class fields (e.g. Kalshi series_ticker / series_title
+            from the parent event, Polymarket series). Passed through verbatim so downstream consumers can recover
+            anything the unified shape omits. Each venue populates what it has.
         sourceExchange:
           type: string
           description: 'The exchange/venue this market originates from (e.g. ''polymarket'', ''kalshi''). Populated by the Router.'
@@ -3003,6 +3010,13 @@ components:
             Optional list of tags. More granular than category — e.g. ["Sports", "FIFA World Cup", "2026 FIFA World
             Cup"] or ["Politics", "Geopolitics", "Middle East"]. Tags vary by venue: Polymarket markets carry several,
             Kalshi typically one.
+        sourceMetadata:
+          type: object
+          additionalProperties: {}
+          description: >-
+            Raw venue-specific metadata not captured by first-class fields (e.g. Kalshi series_ticker / series_title,
+            Polymarket series). Passed through verbatim so downstream consumers can recover anything the unified shape
+            omits. Each venue populates what it has.
         sourceExchange:
           type: string
           description: 'The exchange/venue this event originates from (e.g. ''polymarket'', ''kalshi''). Populated by the Router.'

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -46,6 +46,9 @@ export interface UnifiedEvent {
     /** Optional list of tags. More granular than category — e.g. ["Sports", "FIFA World Cup", "2026 FIFA World Cup"] or ["Politics", "Geopolitics", "Middle East"]. Tags vary by venue: Polymarket markets carry several, Kalshi typically one. */
     tags?: string[];
 
+    /** Raw venue-specific metadata not captured by first-class fields (e.g. Kalshi series_ticker / series_title, Polymarket series). Passed through verbatim so downstream consumers can recover anything the unified shape omits. Each venue populates what it has. */
+    sourceMetadata?: Record<string, unknown>;
+
     /** The exchange/venue this event originates from (e.g. 'polymarket', 'kalshi'). Populated by the Router. */
     sourceExchange?: string;
 }
@@ -89,6 +92,9 @@ export interface UnifiedMarket {
     status?: string;
     /** On-chain contract / condition identifier where applicable (Polymarket conditionId, etc.). */
     contractAddress?: string;
+
+    /** Raw venue-specific metadata not captured by first-class fields (e.g. Kalshi series_ticker / series_title from the parent event, Polymarket series). Passed through verbatim so downstream consumers can recover anything the unified shape omits. Each venue populates what it has. */
+    sourceMetadata?: Record<string, unknown>;
 
     /** The exchange/venue this market originates from (e.g. 'polymarket', 'kalshi'). Populated by the Router. */
     sourceExchange?: string;

--- a/core/src/utils/metadata.ts
+++ b/core/src/utils/metadata.ts
@@ -1,0 +1,35 @@
+/**
+ * Build a `sourceMetadata` object from a raw venue payload, capturing only the
+ * venue-specific data that the unified shape would otherwise drop.
+ *
+ * Keys listed in `promotedKeys` are omitted because they are already
+ * represented by first-class Unified / DB columns (price, volume, status, ...),
+ * so keeping them here would duplicate data. Everything else on the raw payload
+ * is preserved verbatim. `extra` adds non-promoted fields that live on a
+ * different raw object (e.g. a parent event's series identifiers attached to a
+ * market); `undefined` extras are skipped so we never store empty keys.
+ *
+ * Returns a new object — the inputs are never mutated.
+ */
+export function buildSourceMetadata(
+    raw: Record<string, unknown> | null | undefined,
+    promotedKeys: readonly string[],
+    extra?: Record<string, unknown>,
+): Record<string, unknown> {
+    const promoted = new Set(promotedKeys);
+    const out: Record<string, unknown> = {};
+
+    if (raw && typeof raw === 'object') {
+        for (const [key, value] of Object.entries(raw)) {
+            if (!promoted.has(key)) out[key] = value;
+        }
+    }
+
+    if (extra) {
+        for (const [key, value] of Object.entries(extra)) {
+            if (value !== undefined) out[key] = value;
+        }
+    }
+
+    return out;
+}

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PMXT Hosted API",
     "description": "One API for every prediction market. Cross-venue search in under 10ms, a single unified schema, and the complete venue surface from reads to trades.",
-    "version": "2.46.14"
+    "version": "2.17.1"
   },
   "servers": [
     {
@@ -274,7 +274,28 @@
         "operationId": "fetchMarkets",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us",
+                "suibets",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -491,23 +512,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
           },
           {
             "lang": "python",
@@ -571,23 +577,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -1055,7 +1046,28 @@
         "operationId": "fetchEvents",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us",
+                "suibets",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -1279,23 +1291,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
           },
           {
             "lang": "python",
@@ -1359,23 +1356,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
           },
           {
             "lang": "javascript",
@@ -2050,7 +2032,23 @@
         "operationId": "fetchOHLCV",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -2170,46 +2168,6 @@
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
           },
           {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Smarkets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
@@ -2248,46 +2206,6 @@
             "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
           }
         ]
       }
@@ -2298,7 +2216,27 @@
         "operationId": "fetchOrderBook",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us",
+                "suibets",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -2426,11 +2364,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
           },
@@ -2441,23 +2374,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
           },
           {
             "lang": "python",
@@ -2506,11 +2424,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
           },
@@ -2521,23 +2434,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -2553,7 +2451,18 @@
         "operationId": "fetchOrderBooks",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -2622,11 +2531,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Kalshi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
           },
@@ -2636,74 +2540,9 @@
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.KalshiDemo(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
           },
           {
-            "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Opinion",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Smarkets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Limitless({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
           },
           {
             "lang": "javascript",
@@ -2714,66 +2553,6 @@
             "lang": "javascript",
             "label": "KalshiDemo",
             "source": "import { KalshiDemo } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new KalshiDemo({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
           }
         ]
       }
@@ -2784,7 +2563,23 @@
         "operationId": "fetchTrades",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "smarkets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -2891,48 +2686,8 @@
           },
           {
             "lang": "python",
-            "label": "Opinion",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
           },
           {
             "lang": "javascript",
@@ -2971,48 +2726,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
           }
         ]
       }
@@ -3023,7 +2738,26 @@
         "operationId": "createOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3142,31 +2876,6 @@
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
@@ -3220,31 +2929,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           }
         ]
       }
@@ -3255,7 +2939,21 @@
         "operationId": "buildOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3325,11 +3023,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
@@ -3340,28 +3033,8 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
           {
             "lang": "python",
@@ -3374,39 +3047,9 @@
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -3420,28 +3063,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -3452,31 +3075,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           }
         ]
       }
@@ -3487,7 +3085,21 @@
         "operationId": "submitOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3557,11 +3169,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
           },
@@ -3572,28 +3179,8 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
           },
           {
             "lang": "python",
@@ -3606,39 +3193,9 @@
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
           },
           {
             "lang": "javascript",
@@ -3652,28 +3209,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
           },
           {
             "lang": "javascript",
@@ -3684,31 +3221,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
           }
         ]
       }
@@ -3719,7 +3231,24 @@
         "operationId": "cancelOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3809,16 +3338,6 @@
           },
           {
             "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
           },
@@ -3836,31 +3355,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.cancel_order(order_id=\"ord-001\")"
           },
           {
             "lang": "javascript",
@@ -3889,16 +3383,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
           },
@@ -3916,31 +3400,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
           }
         ]
       }
@@ -3951,7 +3410,23 @@
         "operationId": "fetchOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "probable",
+                "baozi",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -3996,11 +3471,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Kalshi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
           },
@@ -4021,18 +3491,8 @@
           },
           {
             "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
           },
           {
             "lang": "python",
@@ -4045,39 +3505,9 @@
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Limitless({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
           },
           {
             "lang": "javascript",
@@ -4101,18 +3531,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
           },
           {
             "lang": "javascript",
@@ -4123,31 +3543,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
           }
         ]
       }
@@ -4158,7 +3553,25 @@
         "operationId": "fetchOpenOrders",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4241,11 +3654,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
           },
@@ -4253,31 +3661,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
           },
           {
             "lang": "javascript",
@@ -4321,11 +3704,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
           },
@@ -4333,31 +3711,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
           }
         ]
       }
@@ -4368,7 +3721,24 @@
         "operationId": "fetchMyTrades",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4483,11 +3853,6 @@
           },
           {
             "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Myriad",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4498,11 +3863,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4510,31 +3870,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
           {
             "lang": "javascript",
@@ -4563,11 +3898,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Myriad",
             "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
@@ -4578,11 +3908,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
@@ -4590,31 +3915,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           }
         ]
       }
@@ -4625,7 +3925,20 @@
         "operationId": "fetchClosedOrders",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "opinion",
+                "smarkets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4706,11 +4019,6 @@
         "x-codeSamples": [
           {
             "lang": "python",
-            "label": "Polymarket",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Limitless",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4726,68 +4034,13 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "javascript",
-            "label": "Polymarket",
-            "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
@@ -4806,63 +4059,13 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           }
         ]
       }
@@ -4873,7 +4076,20 @@
         "operationId": "fetchAllOrders",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "opinion",
+                "smarkets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4954,11 +4170,6 @@
         "x-codeSamples": [
           {
             "lang": "python",
-            "label": "Polymarket",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Limitless",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4974,68 +4185,13 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "javascript",
-            "label": "Polymarket",
-            "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
@@ -5054,63 +4210,13 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           }
         ]
       }
@@ -5121,7 +4227,26 @@
         "operationId": "fetchPositions",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us",
+                "suibets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -5204,11 +4329,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
           },
@@ -5219,28 +4339,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
           },
           {
             "lang": "javascript",
@@ -5284,11 +4384,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
           },
@@ -5299,28 +4394,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
           }
         ]
       }
@@ -5331,7 +4406,24 @@
         "operationId": "fetchBalance",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -5409,16 +4501,6 @@
           },
           {
             "lang": "python",
-            "label": "Opinion",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
           },
@@ -5426,31 +4508,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
           },
           {
             "lang": "javascript",
@@ -5489,16 +4546,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
           },
@@ -5506,31 +4553,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
           }
         ]
       }
@@ -10318,6 +9340,11 @@
             "type": "string",
             "description": "On-chain contract / condition identifier where applicable (Polymarket conditionId, etc.)."
           },
+          "sourceMetadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Raw venue-specific metadata not captured by first-class fields (e.g. Kalshi series_ticker / series_title from the parent event, Polymarket series). Passed through verbatim so downstream consumers can recover anything the unified shape omits. Each venue populates what it has."
+          },
           "sourceExchange": {
             "type": "string",
             "description": "The exchange/venue this market originates from (e.g. 'polymarket', 'kalshi'). Populated by the Router."
@@ -10454,6 +9481,11 @@
               "type": "string"
             },
             "description": "Optional list of tags. More granular than category — e.g. [\"Sports\", \"FIFA World Cup\", \"2026 FIFA World Cup\"] or [\"Politics\", \"Geopolitics\", \"Middle East\"]. Tags vary by venue: Polymarket markets carry several, Kalshi typically one."
+          },
+          "sourceMetadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Raw venue-specific metadata not captured by first-class fields (e.g. Kalshi series_ticker / series_title, Polymarket series). Passed through verbatim so downstream consumers can recover anything the unified shape omits. Each venue populates what it has."
           },
           "sourceExchange": {
             "type": "string",

--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -1101,13 +1101,24 @@ class Exchange(ABC):
             raise self._parse_api_exception(e) from None
 
     def unwatch_order_book(self, outcome_id: Union[str, "MarketOutcome"] = _UNSET, **_compat_kwargs) -> None:
-        outcome_id = _compat_id(outcome_id, _compat_kwargs)
-        outcome_id = _resolve_outcome_id(outcome_id)
-        self._unwatch_required_via_ws(
-            "unwatch_order_book",
-            "unwatchOrderBook",
-            [outcome_id],
-        )
+        try:
+            args = []
+            outcome_id = _compat_id(outcome_id, _compat_kwargs)
+            args.append(_resolve_outcome_id(outcome_id))
+            body: dict = {"args": args}
+            creds = self._get_credentials_dict()
+            if creds:
+                body["credentials"] = creds
+            url = f"{self._resolve_sidecar_host()}/api/{self.exchange_name}/unwatchOrderBook"
+            headers = {"Content-Type": "application/json", "Accept": "application/json"}
+            headers.update(self._get_auth_headers())
+            response = self._fetch_with_retry(
+                lambda: self._api_client.call_api(method="POST", url=url, body=body, header_params=headers)
+            )
+            response.read()
+            self._handle_response(json.loads(response.data))
+        except ApiException as e:
+            raise self._parse_api_exception(e) from None
 
     def unwatch_address(self, address: str) -> None:
         try:

--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -1215,32 +1215,24 @@ export abstract class Exchange {
 
     async unwatchOrderBook(outcomeId: string | MarketOutcome): Promise<void> {
         await this.initPromise;
-        const resolvedOutcomeId = resolveOutcomeId(outcomeId);
-        const args: any[] = [resolvedOutcomeId];
         try {
-            const ws = await this.getOrCreateWs();
-            if (!ws) {
-                throw this.wsTransportUnavailableError("unwatchOrderBook");
+            const args: any[] = [];
+            args.push(resolveOutcomeId(outcomeId));
+            const response = await this.fetchWithRetry(`${this.resolveBaseUrl()}/api/${this.exchangeName}/unwatchOrderBook`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
+                body: JSON.stringify({ args, credentials: this.getCredentials() }),
+            });
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                if (body.error && typeof body.error === "object") {
+                    throw fromServerError(body.error);
+                }
+                throw new PmxtError(body.error?.message || response.statusText);
             }
-
-            const requestId = this.getWsSubscriptionId(ws, "watchOrderBook", args)
-                ?? `req-${Math.random().toString(36).slice(2, 14)}`;
-
-            await this.sendWsMessage(
-                ws,
-                {
-                    id: requestId,
-                    action: "unsubscribe",
-                    exchange: this.exchangeName,
-                    method: "unwatchOrderBook",
-                    args,
-                },
-            );
-            this.clearWsSubscription(ws, "watchOrderBook", args);
+            const json = await response.json();
+            this.handleResponse(json);
         } catch (error) {
-            if (this.isWsTransportUnavailableError(error)) {
-                throw this.wsTransportUnavailableError("unwatchOrderBook");
-            }
             if (error instanceof PmxtError) throw error;
             throw new PmxtError(`Failed to unwatchOrderBook: ${error}`);
         }


### PR DESCRIPTION
## Summary

- Adds optional `sourceMetadata?: Record<string, unknown>` to `UnifiedEvent` and `UnifiedMarket` (`core/src/types.ts`) for capturing venue-specific raw fields that are not promoted to first-class unified columns.
- New shared helper `buildSourceMetadata(raw, promotedKeys, extra?)` at `core/src/utils/metadata.ts` — returns a new object with non-promoted keys preserved plus optional extras attached.
- Populated by every venue normalizer (13 venues): Kalshi, Polymarket, Polymarket US, Limitless, Smarkets, Opinion, Myriad, Probable, Metaculus, Baozi, Gemini-Titan, Hyperliquid, SuiBets. Each defines its own \`as const\` promoted-key constants per venue.
- Recurring/series identifiers ride along where the venue exposes them: Kalshi \`series_ticker\` / \`series_title\`, Polymarket \`series\` / \`seriesSlug\` (when the event has one — the gamma \`/events\` endpoint embeds the series object inline, no separate fetch needed in the common case), Opinion \`collection\` (with \`frequency\` / \`current\` / \`next\`), Gemini-Titan \`series\`.
- Backward compatible: the new field is optional; all 42 existing referencers continue to typecheck. No DB migration in this pass — the field is consumed by the hosted-pmxt mapper into the existing \`source_metadata\` jsonb column (see follow-up PR).

## Test plan

- [x] \`npx tsc --noEmit -p core\` exit 0 (combined typecheck across all 13 venues).
- [x] Per-venue tsx proof: promoted keys stripped, non-promoted preserved, \`extra\` identifiers attached.
- [x] Kalshi live sidecar round-trip — \`series_ticker\` / \`series_title\` land in event + market \`sourceMetadata\`.
- [ ] After merge + hosted-pmxt deploy: \`POST /internal/ingest\` with limit 50; verify \`SELECT source_metadata FROM prediction_markets.events / markets WHERE source_metadata <> '{}'\` returns populated rows.