### PR TITLE
fix: tolerate flat POST bodies (treat as positional args[0])

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.48.1] - 2026-05-30
+
+### Fixed
+
+- **Server**: `POST /api/<exchange>/<method>` now tolerates flat-body requests like `{"slug":"wta"}` in addition to the existing `{"args":[{"slug":"wta"}]}` envelope. Previously, flat bodies caused all filter parameters to be silently dropped (the method was invoked with no arguments). The Python and TypeScript SDKs were not affected — they always wrap params in `args` — but raw `curl` callers and documentation examples hit this. Empty bodies still behave as `args:[]`.
+
 ## [2.48.0] - 2026-05-30
 
 ### Added

--- a/core/src/server/app.ts
+++ b/core/src/server/app.ts
@@ -475,17 +475,30 @@ export function createApp(options: CreateAppOptions = {}): Express {
 
   // POST /api/:exchange/:method
   //
-  // The original RPC-shaped surface. Body: { args: any[], credentials? }.
+  // Supports two calling conventions:
+  //   - Envelope:   { args: [...], credentials? }  — original RPC shape, used by SDKs
+  //   - Flat body:  { slug: "wta", limit: 3, ... } — raw-curl / documentation examples
+  //
+  // When `args` is a valid array it is used directly (envelope path).
+  // When the body is a plain object without an `args` array, the body minus
+  // the reserved envelope keys (`args`, `credentials`) becomes args[0].
   // Accepts every method, including reads — so pre-existing clients
   // that POST reads keep working forever.
   app.post(
     "/api/:exchange/:method",
     async (req: Request, res: Response, next: NextFunction) => {
       const methodName = req.params.method as string;
-      const args = Array.isArray(req.body.args) ? req.body.args : [];
-      const credentials = req.body.credentials as
-        | ExchangeCredentials
-        | undefined;
+      const body = req.body as Record<string, unknown>;
+      const credentials = body.credentials as ExchangeCredentials | undefined;
+      let args: unknown[];
+      if (Array.isArray(body.args)) {
+        args = body.args;
+      } else if (body && typeof body === 'object' && !Array.isArray(body)) {
+        const { args: _ignored, credentials: _creds, ...rest } = body;
+        args = Object.keys(rest).length > 0 ? [rest] : [];
+      } else {
+        args = [];
+      }
       await dispatchMethod(req, res, next, methodName, args, credentials);
     },
   );

--- a/core/test/pipeline/get-post-parity.test.ts
+++ b/core/test/pipeline/get-post-parity.test.ts
@@ -315,4 +315,38 @@ describe('GET/POST parity (mock exchange)', () => {
             expect(body.error.message).not.toContain('Cannot read properties');
         });
     });
+
+    describe('flat-body POST (no args envelope)', () => {
+        it('treats a flat body as the first positional arg', async () => {
+            // Flat body: { limit: 3 } instead of { args: [{ limit: 3 }] }
+            const res = await fetch(`${baseUrl}/api/mock/fetchMarkets`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ limit: 3 }),
+            });
+            const responseBody = (await res.json()) as ApiResponse<unknown[]>;
+            expect(responseBody.success).toBe(true);
+            expect((responseBody as ApiSuccess<unknown[]>).data.length).toBe(3);
+        });
+
+        it('an empty flat body (no keys) produces the same result as args:[]', async () => {
+            const [flatResult, envelopeResult] = await Promise.all([
+                fetch(`${baseUrl}/api/mock/fetchMarkets`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({}),
+                }).then((r) => r.json()) as Promise<ApiResponse<unknown[]>>,
+                fetch(`${baseUrl}/api/mock/fetchMarkets`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ args: [] }),
+                }).then((r) => r.json()) as Promise<ApiResponse<unknown[]>>,
+            ]);
+            expect(flatResult.success).toBe(true);
+            expect(envelopeResult.success).toBe(true);
+            expect(
+                (flatResult as ApiSuccess<unknown[]>).data.length,
+            ).toBe((envelopeResult as ApiSuccess<unknown[]>).data.length);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

`POST /api/<exchange>/<method>` previously required the envelope \`{"args":[{...}]}\`. Flat bodies like \`{"slug":"wta"}\` caused \`req.body.args\` to be \`undefined\`, fell back to \`[]\`, and the method was invoked with no arguments — every filter / limit / id / slug was silently dropped.

The TypeScript and Python SDKs already wrap params in \`args\` (so they were unaffected), but raw \`curl\` callers and documentation examples tripped this every time. End-to-end series tests against \`api.pmxt.dev\` exposed it across all venues / methods.

## Fix

\`core/src/server/app.ts\` — three-branch guard:
1. \`body.args\` is a valid array → use it directly (existing path).
2. \`body\` is a plain object with no \`args\` array → strip reserved keys (\`args\`, \`credentials\`) and wrap the remainder as \`args[0]\`.
3. Everything else → \`args = []\`.

Credentials extraction is preserved on all branches.

## Test plan

- [x] Added \`core/test/pipeline/get-post-parity.test.ts\` covering flat-body + empty-body cases — 9/9 green.
- [x] \`npx tsc --noEmit -p core\` exit 0.
- [ ] After deploy: \`POST api.pmxt.dev/api/polymarket/fetchSeries -d '{"slug":"wta"}'\` returns 1 series (not 20).