### PR TITLE
fix(python-sdk): rename Suibets to SuiBets for cross-SDK consistency

### DIFF
--- a/core/scripts/generate-python-exchanges.js
+++ b/core/scripts/generate-python-exchanges.js
@@ -34,6 +34,12 @@ const OVERRIDES = {
             wallet_address: 'Wallet address (required for positions and balance)',
         },
     },
+    suibets: {
+        // Exchange name has no separator; force the canonical PascalCase used
+        // by the TypeScript SDK and core engine. The default-derived "Suibets"
+        // is emitted as a backwards-compatible alias.
+        className: 'SuiBets',
+    },
 };
 
 function toClassName(name) {
@@ -41,6 +47,14 @@ function toClassName(name) {
         .split(/[-_]/)
         .map(part => part.toLowerCase() === 'us' ? 'US' : part.charAt(0).toUpperCase() + part.slice(1))
         .join('');
+}
+
+// Resolve the canonical Python class name for an exchange wire key, honoring
+// any explicit override in OVERRIDES[name].className. Use this instead of
+// calling toClassName() directly so overrides apply everywhere consistently.
+function classNameFor(name) {
+    const ov = OVERRIDES[name] || {};
+    return ov.className || toClassName(name);
 }
 
 function toLegacyClassName(name) {
@@ -111,7 +125,7 @@ function build(name, block) {
 
 function generateClass(exchange) {
     const { name, creds } = exchange;
-    const className = toClassName(name);
+    const className = classNameFor(name);
     const ov = OVERRIDES[name] || {};
     const aliases = ov.paramAliases || {};
     const defaults = ov.defaults || {};
@@ -226,7 +240,7 @@ function generateClass(exchange) {
 const appTs = fs.readFileSync(APP_TS_PATH, 'utf8');
 const exchanges = parseExchanges(appTs);
 const legacyAliases = exchanges
-    .map(ex => ({ legacyName: toLegacyClassName(ex.name), className: toClassName(ex.name) }))
+    .map(ex => ({ legacyName: toLegacyClassName(ex.name), className: classNameFor(ex.name) }))
     .filter(alias => alias.legacyName !== alias.className);
 
 const header = [
@@ -256,14 +270,14 @@ const aliasBlock = legacyAliases.length
 fs.writeFileSync(OUTPUT_PATH, header + body + aliasBlock);
 console.log(`Generated ${exchanges.length} exchange classes -> ${path.relative(process.cwd(), OUTPUT_PATH)}`);
 for (const ex of exchanges) {
-    console.log(`  ${toClassName(ex.name)} (exchange_name="${ex.name}")`);
+    console.log(`  ${classNameFor(ex.name)} (exchange_name="${ex.name}")`);
 }
 
 // ---------------------------------------------------------------------------
 // Update __init__.py imports and __all__ to match generated exchanges
 // ---------------------------------------------------------------------------
 const classNames = exchanges.flatMap(ex => {
-    const className = toClassName(ex.name);
+    const className = classNameFor(ex.name);
     const legacyName = toLegacyClassName(ex.name);
     return legacyName === className ? [className] : [className, legacyName];
 });

--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -164,7 +164,7 @@ __all__ = [
     "Hyperliquid",
     "GeminiTitan",
     "SuiBets",
-    "Suibets",  # deprecated alias, retained for backwards compatibility
+    "Suibets",
     "Mock",
     "Router",
     "Exchange",

--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -19,7 +19,7 @@ Example:
 from typing import Any, Dict, List
 
 from .client import Exchange
-from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, PolymarketUS, Polymarket_us, Hyperliquid, GeminiTitan, Suibets, Mock, Router
+from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, PolymarketUS, Polymarket_us, Hyperliquid, GeminiTitan, SuiBets, Suibets, Mock, Router
 from .router import Router
 from .server_manager import ServerManager
 from .errors import (
@@ -163,7 +163,8 @@ __all__ = [
     "Polymarket_us",
     "Hyperliquid",
     "GeminiTitan",
-    "Suibets",
+    "SuiBets",
+    "Suibets",  # deprecated alias, retained for backwards compatibility
     "Mock",
     "Router",
     "Exchange",

--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -495,11 +495,6 @@ class SuiBets(Exchange):
         )
 
 
-# Deprecated alias kept for backwards compatibility with the lowercase-b spelling.
-# Remove in a future major version.
-Suibets = SuiBets
-
-
 class Mock(Exchange):
     """Mock exchange client."""
 
@@ -551,3 +546,4 @@ class Router(Exchange):
 
 # Backwards-compatible aliases for exchange classes generated before underscore handling.
 Polymarket_us = PolymarketUS
+Suibets = SuiBets

--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -470,8 +470,8 @@ class GeminiTitan(Exchange):
         return creds if creds else None
 
 
-class Suibets(Exchange):
-    """Suibets exchange client."""
+class SuiBets(Exchange):
+    """SuiBets exchange client."""
 
     def __init__(
         self,
@@ -480,7 +480,7 @@ class Suibets(Exchange):
         pmxt_api_key: Optional[str] = None,
     ):
         """
-        Initialize Suibets client.
+        Initialize SuiBets client.
 
         Args:
             base_url: Base URL of the PMXT sidecar server
@@ -493,6 +493,11 @@ class Suibets(Exchange):
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,
         )
+
+
+# Deprecated alias kept for backwards compatibility with the lowercase-b spelling.
+# Remove in a future major version.
+Suibets = SuiBets
 
 
 class Mock(Exchange):


### PR DESCRIPTION
Closes #773

## Summary
The TypeScript SDK and core engine both use `SuiBets` as the canonical class name. The Python SDK was the odd one out with the lowercase-b `Suibets`, breaking exchange-agnostic naming consistency across SDKs.

## Changes
- `sdks/python/pmxt/_exchanges.py`: rename class `Suibets` → `SuiBets`; keep `Suibets = SuiBets` deprecation alias so existing callers don't break.
- `sdks/python/pmxt/__init__.py`: import and export both names; mark `Suibets` in `__all__` as deprecated alias.

The `exchange_name="suibets"` registration string is unchanged (matches the issue's "registered identifier" note).

## Test plan
- [x] \`python -m py_compile sdks/python/pmxt/_exchanges.py sdks/python/pmxt/__init__.py\` passes
- [ ] \`from pmxt import SuiBets\` works for new callers
- [ ] \`from pmxt import Suibets\` still works for existing callers